### PR TITLE
Add Multihash.Encode/Decode for spec-compliant multihash construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [1.3.0] - 2026-03-15
+
+### Added
+
+- `Multihash.Encode(ulong hashFunctionCode, ReadOnlySpan<byte> digest)` for constructing spec-compliant multihash bytes: `varint(code) || varint(digestLength) || digest` ([#7](https://github.com/moisesja/net-cid/issues/7))
+- `Multihash.Decode` and `Multihash.TryDecode` for parsing multihash byte sequences back into code and digest
+
 ## [1.2.1] - 2026-03-08
 
 ### Fixed
@@ -37,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SHA-256 and SHA-512 multihash support
 - Core multicodec constants (raw, dag-pb, dag-cbor, etc.)
 
-[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/moisesja/net-cid/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/moisesja/net-cid/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/moisesja/net-cid/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/moisesja/net-cid/compare/v1.0.0...v1.1.0

--- a/NetCid.Tests/MultihashTests.cs
+++ b/NetCid.Tests/MultihashTests.cs
@@ -1,0 +1,95 @@
+using System.Security.Cryptography;
+
+namespace NetCid.Tests;
+
+public sealed class MultihashTests
+{
+    [Fact]
+    public void Encode_ProducesCorrectMultihashFormat()
+    {
+        var data = "hello world"u8;
+        var digest = SHA256.HashData(data);
+        var multihash = Multihash.Encode(MultihashCode.Sha2_256, digest);
+
+        // varint(0x12) = [0x12], varint(32) = [0x20], digest = 32 bytes → total 34 bytes
+        Assert.Equal(34, multihash.Length);
+        Assert.Equal(0x12, multihash[0]);
+        Assert.Equal(0x20, multihash[1]);
+        Assert.Equal(digest, multihash[2..]);
+    }
+
+    [Fact]
+    public void Encode_DiffersFromMulticodecPrefix()
+    {
+        var digest = SHA256.HashData("test"u8);
+
+        var multihash = Multihash.Encode(MultihashCode.Sha2_256, digest);
+        var multicodecPrefixed = Multicodec.Prefix(MultihashCode.Sha2_256, digest);
+
+        // Multihash has an extra varint for digest length
+        Assert.Equal(34, multihash.Length);   // varint(code) + varint(length) + digest
+        Assert.Equal(33, multicodecPrefixed.Length); // varint(code) + digest (no length!)
+        Assert.NotEqual(multihash, multicodecPrefixed);
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTrips()
+    {
+        var digest = SHA256.HashData("net-cid"u8);
+        var multihash = Multihash.Encode(MultihashCode.Sha2_256, digest);
+
+        var (code, decoded) = Multihash.Decode(multihash);
+
+        Assert.Equal(MultihashCode.Sha2_256, code);
+        Assert.Equal(digest, decoded);
+    }
+
+    [Fact]
+    public void TryDecode_ReturnsTrueForValidMultihash()
+    {
+        var digest = SHA256.HashData("test"u8);
+        var multihash = Multihash.Encode(MultihashCode.Sha2_256, digest);
+
+        Assert.True(Multihash.TryDecode(multihash, out var code, out var decoded));
+        Assert.Equal(MultihashCode.Sha2_256, code);
+        Assert.Equal(digest, decoded);
+    }
+
+    [Fact]
+    public void TryDecode_ReturnsFalseForTruncatedInput()
+    {
+        // Valid header but truncated digest
+        var invalid = new byte[] { 0x12, 0x20, 0x01, 0x02 };
+
+        Assert.False(Multihash.TryDecode(invalid, out _, out _));
+    }
+
+    [Fact]
+    public void Decode_ThrowsForInvalidInput()
+    {
+        Assert.Throws<CidFormatException>(() => Multihash.Decode(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void Encode_MatchesMultihashDigestToByteArray()
+    {
+        var digest = SHA256.HashData("consistency"u8);
+
+        var viaHelper = Multihash.Encode(MultihashCode.Sha2_256, digest);
+        var viaStruct = new MultihashDigest(MultihashCode.Sha2_256, digest).ToByteArray();
+
+        Assert.Equal(viaStruct, viaHelper);
+    }
+
+    [Fact]
+    public void Encode_Sha512_ProducesCorrectLength()
+    {
+        var digest = SHA512.HashData("test"u8);
+        var multihash = Multihash.Encode(MultihashCode.Sha2_512, digest);
+
+        // varint(0x13) = [0x13], varint(64) = [0x40], digest = 64 bytes → total 66 bytes
+        Assert.Equal(66, multihash.Length);
+        Assert.Equal(0x13, multihash[0]);
+        Assert.Equal(0x40, multihash[1]);
+    }
+}

--- a/NetCid/Multihash.cs
+++ b/NetCid/Multihash.cs
@@ -1,0 +1,41 @@
+namespace NetCid;
+
+/// <summary>
+/// Static helpers for multihash encoding and decoding.
+/// A multihash is: varint(hashFunctionCode) || varint(digestLength) || digest.
+/// See https://multiformats.io/multihash/
+/// </summary>
+public static class Multihash
+{
+    /// <summary>
+    /// Encode a digest as a multihash: varint(hashFunctionCode) || varint(digestLength) || digest.
+    /// </summary>
+    public static byte[] Encode(ulong hashFunctionCode, ReadOnlySpan<byte> digest)
+        => new MultihashDigest(hashFunctionCode, digest).ToByteArray();
+
+    /// <summary>
+    /// Decode a multihash byte sequence into its hash function code and raw digest.
+    /// </summary>
+    public static (ulong Code, byte[] Digest) Decode(ReadOnlySpan<byte> multihash)
+    {
+        var parsed = MultihashDigest.Parse(multihash, out _);
+        return (parsed.Code, parsed.GetDigestBytes());
+    }
+
+    /// <summary>
+    /// Try to decode a multihash byte sequence.
+    /// </summary>
+    public static bool TryDecode(ReadOnlySpan<byte> multihash, out ulong code, out byte[]? digest)
+    {
+        if (MultihashDigest.TryParse(multihash, out var parsed, out _))
+        {
+            code = parsed.Code;
+            digest = parsed.GetDigestBytes();
+            return true;
+        }
+
+        code = 0;
+        digest = null;
+        return false;
+    }
+}

--- a/NetCid/NetCid.csproj
+++ b/NetCid/NetCid.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>NetCid</PackageId>
-    <Version>1.2.1</Version>
+    <Version>1.3.0</Version>
     <Authors>NetCid Contributors</Authors>
     <Description>Multiformats CID implementation for .NET.</Description>
     <PackageTags>cid;multiformats;ipfs;multibase;multicodec;multihash</PackageTags>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Binary CID decode/encode
 - Unsigned varint codec (multiformats-compatible, max 9-byte encoding)
 - Multihash model + SHA-256 / SHA-512 hash helpers
+- `Multihash.Encode` / `Decode` for spec-compliant multihash wire format (`varint(code) || varint(digestLength) || digest`)
 - Multibase support for:
   - `base58btc` (`z`)
   - `base32` lower/upper (`b` / `B`)

--- a/examples/multihash-interface/Program.cs
+++ b/examples/multihash-interface/Program.cs
@@ -1,17 +1,47 @@
+using System.Security.Cryptography;
 using System.Text.Json;
 using NetCid;
 
 var value = new Dictionary<string, string> { ["hello"] = "world" };
 var bytes = JsonSerializer.SerializeToUtf8Bytes(value);
 
+// --- MultihashDigest (high-level API) ---
+
+Console.WriteLine("MultihashDigest (high-level API):\n");
+
 var sha256Digest = MultihashDigest.Sha2_256(bytes);
 var cid256 = Cid.CreateV1(Multicodec.DagJson, sha256Digest);
 
-Console.WriteLine($"sha2-256 digest size: {sha256Digest.DigestLength}");
-Console.WriteLine($"CID (sha2-256): {cid256}");
+Console.WriteLine($"  sha2-256 digest size: {sha256Digest.DigestLength}");
+Console.WriteLine($"  CID (sha2-256): {cid256}");
 
 var sha512Digest = MultihashDigest.Sha2_512(bytes);
 var cid512 = Cid.CreateV1(Multicodec.DagJson, sha512Digest);
 
-Console.WriteLine($"sha2-512 digest size: {sha512Digest.DigestLength}");
-Console.WriteLine($"CID (sha2-512): {cid512}");
+Console.WriteLine($"  sha2-512 digest size: {sha512Digest.DigestLength}");
+Console.WriteLine($"  CID (sha2-512): {cid512}");
+
+// --- Multihash.Encode (low-level wire format) ---
+
+Console.WriteLine("\nMultihash.Encode (low-level wire format):\n");
+
+var rawDigest = SHA256.HashData(bytes);
+var multihash = Multihash.Encode(MultihashCode.Sha2_256, rawDigest);
+
+Console.WriteLine($"  Raw SHA-256 digest:  {rawDigest.Length} bytes");
+Console.WriteLine($"  Multihash encoded:   {multihash.Length} bytes (varint code + varint length + digest)");
+Console.WriteLine($"  Hex: {Convert.ToHexString(multihash).ToLowerInvariant()}");
+
+// Show the difference vs Multicodec.Prefix (which lacks the digest length varint)
+var incorrectPrefix = Multicodec.Prefix(MultihashCode.Sha2_256, rawDigest);
+Console.WriteLine($"\n  Multicodec.Prefix (WRONG for multihash): {incorrectPrefix.Length} bytes — missing digest length varint");
+Console.WriteLine($"  Multihash.Encode  (CORRECT):             {multihash.Length} bytes — includes digest length varint");
+
+// --- Multihash.Decode round-trip ---
+
+Console.WriteLine("\nMultihash.Decode round-trip:\n");
+
+var (code, decoded) = Multihash.Decode(multihash);
+Console.WriteLine($"  Code:          0x{code:X2} (sha2-256)");
+Console.WriteLine($"  Digest length: {decoded.Length}");
+Console.WriteLine($"  Match:         {rawDigest.SequenceEqual(decoded)}");


### PR DESCRIPTION
## Summary
- Adds `Multihash.Encode(ulong hashFunctionCode, ReadOnlySpan<byte> digest)` that produces the correct multihash wire format: `varint(code) || varint(digestLength) || digest`
- Adds `Multihash.Decode` and `Multihash.TryDecode` for parsing multihash bytes back into code + digest
- Prevents consumers from misusing `Multicodec.Prefix` (which omits the digest length varint) for multihash construction
- Bumps version to 1.3.0 (new public API surface)

Fixes #7

## Files changed
- **`NetCid/Multihash.cs`** — new static helper class delegating to `MultihashDigest`
- **`NetCid.Tests/MultihashTests.cs`** — 8 tests covering encode, decode, round-trip, error cases, and explicit comparison with `Multicodec.Prefix`
- **`examples/multihash-interface/Program.cs`** — expanded to demonstrate `Multihash.Encode`/`Decode` and show why `Multicodec.Prefix` is wrong for multihash
- **`CHANGELOG.md`** — 1.3.0 entry
- **`README.md`** — added feature bullet
- **`NetCid.csproj`** — version bump to 1.3.0

## Test plan
- [x] `Encode` produces correct 34-byte output for SHA-256 (code `0x12` + length `0x20` + 32-byte digest)
- [x] `Encode` output differs from `Multicodec.Prefix` (33 bytes vs 34 bytes)
- [x] `Encode`/`Decode` round-trips correctly
- [x] `TryDecode` returns false for truncated input
- [x] `Decode` throws `CidFormatException` for empty input
- [x] `Encode` matches `MultihashDigest.ToByteArray()` output exactly
- [x] SHA-512 variant produces correct 66-byte output
- [x] All 78 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)