### PR TITLE
Add JCS (RFC 8785) JSON canonicalization for stable CIDs over JSON (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [1.4.0] - 2026-05-21
+
+### Added
+
+- `JcsCanonicalizer` — RFC 8785 JSON Canonicalization Scheme (JCS) producing a deterministic UTF-8 serialization of any supported JSON value, with overloads for `JsonNode?`, `JsonElement`, and direct `IBufferWriter<byte>` writes ([#9](https://github.com/moisesja/net-cid/issues/9))
+- `Cid.FromCanonicalJson(JsonNode?, codec, hashCode)` convenience overload that canonicalizes JSON and computes the resulting CID in one call
+- `JcsFormatException` for values JCS cannot represent deterministically (`NaN`, `±infinity`, fractional/exponential numbers in v1, out-of-range integers)
+
+### Notes
+
+- v1 scope covers objects, arrays, strings, integer-valued numbers within `[long.MinValue, ulong.MaxValue]`, booleans, and null. Fractional/IEEE 754 numbers throw `JcsFormatException` and are tracked for a follow-up release.
+
 ## [1.3.0] - 2026-03-15
 
 ### Added
@@ -44,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SHA-256 and SHA-512 multihash support
 - Core multicodec constants (raw, dag-pb, dag-cbor, etc.)
 
-[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/moisesja/net-cid/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/moisesja/net-cid/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/moisesja/net-cid/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/moisesja/net-cid/compare/v1.1.0...v1.2.0

--- a/NetCid.IntegrationTests/JcsCidRoundTripTests.cs
+++ b/NetCid.IntegrationTests/JcsCidRoundTripTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json.Nodes;
+
+namespace NetCid.IntegrationTests;
+
+public sealed class JcsCidRoundTripTests
+{
+    [Fact]
+    public void FromCanonicalJson_Equals_FromContent_Over_Canonical_Bytes()
+    {
+        var node = new JsonObject
+        {
+            ["seq"] = 1,
+            ["op"] = "wallet.mint_identity",
+            ["params_hash"] = "bafyparams",
+            ["prev_cid"] = "genesis",
+        };
+
+        var convenience = Cid.FromCanonicalJson(node);
+
+        var canonical = JcsCanonicalizer.Canonicalize(node);
+        var twoStep = Cid.FromContent(canonical, Multicodec.Raw, MultihashCode.Sha2_256);
+
+        Assert.Equal(twoStep, convenience);
+        Assert.Equal(CidVersion.V1, convenience.Version);
+        Assert.Equal(Multicodec.Raw, convenience.Codec);
+    }
+
+    [Fact]
+    public void Two_Writers_Of_Same_Logical_Value_Produce_Same_Cid()
+    {
+        // Different key insertion orders, same logical object → identical CID.
+        var writerA = new JsonObject
+        {
+            ["b"] = 2,
+            ["a"] = new JsonObject { ["y"] = 2, ["x"] = 1 },
+        };
+
+        var writerB = new JsonObject
+        {
+            ["a"] = new JsonObject { ["x"] = 1, ["y"] = 2 },
+            ["b"] = 2,
+        };
+
+        var cidA = Cid.FromCanonicalJson(writerA);
+        var cidB = Cid.FromCanonicalJson(writerB);
+
+        Assert.Equal(cidA, cidB);
+    }
+
+    [Fact]
+    public void FromCanonicalJson_Honours_Custom_Codec_And_HashCode()
+    {
+        var node = new JsonObject { ["k"] = "v" };
+
+        var cid = Cid.FromCanonicalJson(node, Multicodec.DagJson, MultihashCode.Sha2_512);
+
+        Assert.Equal(Multicodec.DagJson, cid.Codec);
+        Assert.Equal(MultihashCode.Sha2_512, cid.Multihash.Code);
+        Assert.Equal(64, cid.Multihash.DigestLength);
+    }
+}

--- a/NetCid.Tests/JcsCanonicalizerTests.cs
+++ b/NetCid.Tests/JcsCanonicalizerTests.cs
@@ -1,0 +1,271 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace NetCid.Tests;
+
+public sealed class JcsCanonicalizerTests
+{
+    private static string Canon(JsonNode? node)
+        => Encoding.UTF8.GetString(JcsCanonicalizer.Canonicalize(node));
+
+    private static string Canon(string json)
+        => Encoding.UTF8.GetString(JcsCanonicalizer.Canonicalize(JsonNode.Parse(json)));
+
+    private static string CanonElement(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return Encoding.UTF8.GetString(JcsCanonicalizer.Canonicalize(doc.RootElement));
+    }
+
+    [Fact]
+    public void Null_Reference_Serializes_As_Null_Literal()
+    {
+        Assert.Equal("null", Canon((JsonNode?)null));
+    }
+
+    [Fact]
+    public void Primitive_True_False_Null()
+    {
+        Assert.Equal("true", Canon(JsonValue.Create(true)));
+        Assert.Equal("false", Canon(JsonValue.Create(false)));
+        Assert.Equal("null", Canon("null"));
+    }
+
+    [Fact]
+    public void Object_Keys_Sort_By_Code_Unit_Pure_Ascii()
+    {
+        Assert.Equal(
+            "{\"a\":2,\"b\":1}",
+            Canon("{\"b\":1,\"a\":2}"));
+    }
+
+    [Fact]
+    public void Object_Keys_Sort_By_Code_Unit_Mixed_Case()
+    {
+        // 'A'(0x41) < 'a'(0x61) by UTF-16 code unit, so uppercase keys come first.
+        Assert.Equal(
+            "{\"A\":1,\"a\":2,\"b\":3}",
+            Canon("{\"b\":3,\"a\":2,\"A\":1}"));
+    }
+
+    [Fact]
+    public void Object_Keys_Sort_Is_Independent_At_Each_Nesting_Level()
+    {
+        Assert.Equal(
+            "{\"a\":{\"x\":1,\"y\":2},\"b\":[3,2,1]}",
+            Canon("{\"b\":[3,2,1],\"a\":{\"y\":2,\"x\":1}}"));
+    }
+
+    [Fact]
+    public void Arrays_Preserve_Order()
+    {
+        // RFC 8785 §3.2.2.1: arrays keep insertion order.
+        Assert.Equal("[3,1,2]", Canon("[3,1,2]"));
+    }
+
+    [Fact]
+    public void Whitespace_Is_Stripped()
+    {
+        Assert.Equal(
+            "{\"a\":1,\"b\":[1,2]}",
+            Canon("  { \"b\" : [ 1 , 2 ] , \"a\" : 1 }  "));
+    }
+
+    [Fact]
+    public void Integer_Numbers_Strip_To_Plain_Digits()
+    {
+        Assert.Equal("0", Canon("0"));
+        Assert.Equal("1", Canon("1"));
+        Assert.Equal("-1", Canon("-1"));
+        Assert.Equal("9007199254740992", Canon("9007199254740992"));  // > 2^53, still a valid long
+    }
+
+    [Fact]
+    public void Negative_Zero_Normalises_To_Zero()
+    {
+        // RFC 8785 §3.2.2.3 references the ECMAScript ToString algorithm, which collapses -0 to "0".
+        Assert.Equal("0", Canon("-0"));
+    }
+
+    [Fact]
+    public void Large_Positive_Integer_Uses_UInt64()
+    {
+        // Beyond long.MaxValue (9223372036854775807) but within ulong range.
+        Assert.Equal("18446744073709551615", Canon("18446744073709551615"));  // ulong.MaxValue
+    }
+
+    [Fact]
+    public void String_With_Seven_Short_Escapes()
+    {
+        var node = JsonValue.Create("\"\\\b\f\n\r\t");
+        Assert.Equal("\"\\\"\\\\\\b\\f\\n\\r\\t\"", Canon(node));
+    }
+
+    [Fact]
+    public void String_With_Control_Bytes_Uses_LowercaseHex_u00XX()
+    {
+        // U+0001 → \u0001, U+001F → \u001f (lowercase hex per JCS §3.2.2.2).
+        var node = JsonValue.Create("\u0001\u001F");
+        Assert.Equal("\"\\u0001\\u001f\"", Canon(node));
+    }
+
+    [Fact]
+    public void String_With_Solidus_Is_NOT_Escaped()
+    {
+        Assert.Equal("\"/path/to\"", Canon(JsonValue.Create("/path/to")));
+    }
+
+    [Fact]
+    public void String_With_Characters_Above_U007F_Stays_Raw_Utf8()
+    {
+        // "é" is U+00E9, UTF-8 bytes C3 A9. JCS forbids \u00E9 escaping above U+007F.
+        var bytes = JcsCanonicalizer.Canonicalize(JsonValue.Create("é"));
+        Assert.Equal(new byte[] { 0x22, 0xC3, 0xA9, 0x22 }, bytes);
+    }
+
+    [Fact]
+    public void String_With_Emoji_Surrogate_Pair_Becomes_4_Byte_Utf8()
+    {
+        // U+1F600 grinning face. UTF-8: F0 9F 98 80.
+        var bytes = JcsCanonicalizer.Canonicalize(JsonValue.Create("\uD83D\uDE00"));
+        Assert.Equal(new byte[] { 0x22, 0xF0, 0x9F, 0x98, 0x80, 0x22 }, bytes);
+    }
+
+    [Fact]
+    public void Audit_Entry_Example_Matches_Expected_Canonical_Form()
+    {
+        // Representative of net-wallet-mcp audit log entries (issue #9).
+        var entry = new JsonObject
+        {
+            ["seq"] = 1,
+            ["ts"] = "2026-05-21T18:00:00Z",
+            ["op"] = "wallet.mint_identity",
+            ["identity_id"] = "id_42",
+            ["params_hash"] = "bafyparams",
+            ["result_hash"] = "bafyresult",
+            ["prev_cid"] = "genesis",
+        };
+
+        const string expected =
+            "{\"identity_id\":\"id_42\",\"op\":\"wallet.mint_identity\","
+            + "\"params_hash\":\"bafyparams\",\"prev_cid\":\"genesis\","
+            + "\"result_hash\":\"bafyresult\",\"seq\":1,"
+            + "\"ts\":\"2026-05-21T18:00:00Z\"}";
+
+        Assert.Equal(expected, Canon(entry));
+    }
+
+    [Fact]
+    public void Idempotence_Reparsing_Canonical_Form_Reproduces_Same_Bytes()
+    {
+        var node = JsonNode.Parse("{\"b\":[3,1,2],\"a\":{\"y\":\"é\",\"x\":1}}");
+        var first = JcsCanonicalizer.Canonicalize(node);
+        var second = JcsCanonicalizer.Canonicalize(JsonNode.Parse(Encoding.UTF8.GetString(first)));
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void JsonElement_Overload_Matches_JsonNode_Overload()
+    {
+        const string raw = "{\"b\":2,\"a\":{\"y\":2,\"x\":1}}";
+        var fromNode = JcsCanonicalizer.Canonicalize(JsonNode.Parse(raw));
+        var fromElement = Encoding.UTF8.GetBytes(CanonElement(raw));
+        Assert.Equal(fromNode, fromElement);
+    }
+
+    [Fact]
+    public void IBufferWriter_Overload_Writes_Same_Bytes_As_Array_Overload()
+    {
+        var node = JsonNode.Parse("{\"b\":2,\"a\":1}");
+        var expected = JcsCanonicalizer.Canonicalize(node);
+
+        var writer = new ArrayBufferWriter<byte>();
+        JcsCanonicalizer.Canonicalize(node, writer);
+
+        Assert.Equal(expected, writer.WrittenSpan.ToArray());
+    }
+
+    [Fact]
+    public void IBufferWriter_Overload_Rejects_Null_Destination()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => JcsCanonicalizer.Canonicalize((JsonNode?)null, null!));
+    }
+
+    [Fact]
+    public void NaN_Throws_JcsFormatException()
+    {
+        var node = JsonValue.Create(double.NaN);
+        var ex = Assert.Throws<JcsFormatException>(() => JcsCanonicalizer.Canonicalize(node));
+        Assert.Contains("NaN", ex.Message);
+    }
+
+    [Fact]
+    public void Positive_Infinity_Throws_JcsFormatException()
+    {
+        var node = JsonValue.Create(double.PositiveInfinity);
+        var ex = Assert.Throws<JcsFormatException>(() => JcsCanonicalizer.Canonicalize(node));
+        Assert.Contains("infinity", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Negative_Infinity_Throws_JcsFormatException()
+    {
+        var node = JsonValue.Create(double.NegativeInfinity);
+        var ex = Assert.Throws<JcsFormatException>(() => JcsCanonicalizer.Canonicalize(node));
+        Assert.Contains("infinity", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Fractional_Number_Throws_JcsFormatException_With_Followup_Hint()
+    {
+        var ex = Assert.Throws<JcsFormatException>(() => Canon("1.5"));
+        Assert.Contains("fractional", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Exponential_Number_Throws_JcsFormatException()
+    {
+        Assert.Throws<JcsFormatException>(() => Canon("1e10"));
+    }
+
+    [Fact]
+    public void Integer_Outside_UInt64_Range_Throws_With_Range_Hint()
+    {
+        // 21 digits > ulong.MaxValue (20 digits).
+        var ex = Assert.Throws<JcsFormatException>(() => Canon("184467440737095516160"));
+        Assert.Contains("range", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Integer_Below_Int64_Minimum_Throws_With_Range_Hint()
+    {
+        // long.MinValue is -9223372036854775808; this is one less than that.
+        var ex = Assert.Throws<JcsFormatException>(() => Canon("-9223372036854775809"));
+        Assert.Contains("range", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Empty_Object_And_Empty_Array_Canonicalise()
+    {
+        Assert.Equal("{}", Canon("{}"));
+        Assert.Equal("[]", Canon("[]"));
+    }
+
+    [Fact]
+    public void Empty_String_Canonicalises()
+    {
+        Assert.Equal("\"\"", Canon(JsonValue.Create("")));
+    }
+
+    [Fact]
+    public void Large_String_Above_Stack_Threshold_Uses_Pool_And_Still_Canonicalises()
+    {
+        // Force the ArrayPool path (string > 256 bytes UTF-8).
+        var big = new string('a', 1024);
+        var expected = "\"" + big + "\"";
+        Assert.Equal(expected, Canon(JsonValue.Create(big)));
+    }
+}

--- a/NetCid.sln
+++ b/NetCid.sln
@@ -35,6 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "did-key-interface", "did-ke
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DidKeyInterfaceExample", "examples\did-key-interface\DidKeyInterfaceExample.csproj", "{EE42C93D-C02E-4EA3-BE69-8FD54E89D299}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JcsInterfaceExample", "examples\jcs-interface\JcsInterfaceExample.csproj", "{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,18 @@ Global
 		{EE42C93D-C02E-4EA3-BE69-8FD54E89D299}.Release|x64.Build.0 = Release|Any CPU
 		{EE42C93D-C02E-4EA3-BE69-8FD54E89D299}.Release|x86.ActiveCfg = Release|Any CPU
 		{EE42C93D-C02E-4EA3-BE69-8FD54E89D299}.Release|x86.Build.0 = Release|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Debug|x64.Build.0 = Debug|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Debug|x86.Build.0 = Debug|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Release|x64.ActiveCfg = Release|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Release|x64.Build.0 = Release|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Release|x86.ActiveCfg = Release|Any CPU
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -170,5 +184,6 @@ Global
 		{761A3D13-6BF8-475D-A0EC-AFA0122E10C0} = {100B6907-208C-ABD7-B230-CB97AE7445EB}
 		{0B2C1638-03C9-18B3-27EF-35A0821F1F92} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 		{EE42C93D-C02E-4EA3-BE69-8FD54E89D299} = {0B2C1638-03C9-18B3-27EF-35A0821F1F92}
+		{B4892D66-7E45-44FA-BB95-0FB8AFC5ED16} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 	EndGlobalSection
 EndGlobal

--- a/NetCid/Cid.cs
+++ b/NetCid/Cid.cs
@@ -1,3 +1,6 @@
+using System.Buffers;
+using System.Text.Json.Nodes;
+
 namespace NetCid;
 
 /// <summary>
@@ -98,6 +101,25 @@ public sealed class Cid : IEquatable<Cid>
         };
 
         return CreateV1(codec, multihash);
+    }
+
+    /// <summary>
+    /// Canonicalize <paramref name="json"/> per RFC 8785 (JCS) and return the resulting CID.
+    /// Equivalent to <c>Cid.FromContent(JcsCanonicalizer.Canonicalize(json), codec, hashCode)</c>
+    /// but writes canonical bytes directly into a pooled buffer to avoid an intermediate
+    /// <c>byte[]</c> allocation.
+    /// </summary>
+    /// <exception cref="JcsFormatException">
+    /// The JSON value cannot be canonicalized — see <see cref="JcsCanonicalizer"/> for the v1 type scope.
+    /// </exception>
+    public static Cid FromCanonicalJson(
+        JsonNode? json,
+        ulong codec = Multicodec.Raw,
+        ulong hashCode = MultihashCode.Sha2_256)
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        JcsCanonicalizer.Canonicalize(json, writer);
+        return FromContent(writer.WrittenSpan, codec, hashCode);
     }
 
     public static Cid Parse(string value)

--- a/NetCid/JcsCanonicalizer.cs
+++ b/NetCid/JcsCanonicalizer.cs
@@ -1,0 +1,389 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace NetCid;
+
+/// <summary>
+/// JSON Canonicalization Scheme (JCS) per
+/// <see href="https://www.rfc-editor.org/rfc/rfc8785">RFC 8785</see>.
+/// Produces a deterministic byte-for-byte stable UTF-8 serialization of a JSON value
+/// so that two writers of the same logical value produce identical bytes — and therefore
+/// identical CIDs, hashes, or signatures.
+/// </summary>
+/// <remarks>
+/// <para>
+/// v1 scope (matches issue #9): supports objects, arrays, strings, integer-valued numbers
+/// in <c>[long.MinValue, ulong.MaxValue]</c>, <c>true</c>, <c>false</c>, and <c>null</c>.
+/// Fractional / exponential numbers, <c>NaN</c>, and <c>±infinity</c> throw
+/// <see cref="JcsFormatException"/>.
+/// </para>
+/// <para>Thread-safe — all members are static and stateless.</para>
+/// </remarks>
+public static class JcsCanonicalizer
+{
+    private const int StackBufferThreshold = 256;
+
+    /// <summary>
+    /// Canonicalize <paramref name="node"/> per RFC 8785. A <see langword="null"/>
+    /// reference is treated as the JSON literal <c>null</c>.
+    /// </summary>
+    /// <returns>UTF-8 encoded canonical JSON bytes.</returns>
+    /// <exception cref="JcsFormatException">
+    /// The node contains a value JCS cannot represent deterministically — for example,
+    /// <c>NaN</c>, <c>±infinity</c>, a fractional number (not supported in v1), or an integer
+    /// outside <c>[long.MinValue, ulong.MaxValue]</c>.
+    /// </exception>
+    public static byte[] Canonicalize(JsonNode? node)
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        Canonicalize(node, writer);
+        return writer.WrittenSpan.ToArray();
+    }
+
+    /// <summary>
+    /// Canonicalize a <see cref="JsonElement"/> per RFC 8785.
+    /// </summary>
+    /// <returns>UTF-8 encoded canonical JSON bytes.</returns>
+    /// <exception cref="JcsFormatException">
+    /// The element contains a value JCS cannot represent deterministically.
+    /// </exception>
+    public static byte[] Canonicalize(JsonElement element)
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        WriteElement(element, writer);
+        return writer.WrittenSpan.ToArray();
+    }
+
+    /// <summary>
+    /// Canonicalize <paramref name="node"/> and write the bytes directly into
+    /// <paramref name="destination"/>. Useful for hashing pipelines that do not want
+    /// an intermediate <c>byte[]</c> allocation.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="destination"/> is <see langword="null"/>.</exception>
+    /// <exception cref="JcsFormatException">
+    /// The node contains a value JCS cannot represent deterministically.
+    /// </exception>
+    public static void Canonicalize(JsonNode? node, IBufferWriter<byte> destination)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+
+        if (node is null)
+        {
+            WriteRaw(destination, "null"u8);
+            return;
+        }
+
+        // JsonNode may wrap raw .NET doubles/floats holding NaN/±infinity. The default
+        // System.Text.Json serializer would throw a generic JsonException; surface a
+        // JCS-specific message instead so callers can handle JcsFormatException uniformly.
+        ValidateNoUnrepresentableNumbers(node);
+
+        JsonDocument document;
+        try
+        {
+            document = JsonSerializer.SerializeToDocument(node);
+        }
+        catch (JsonException ex)
+        {
+            throw new JcsFormatException(
+                "JSON value cannot be serialized for canonicalization.", ex);
+        }
+
+        using (document)
+        {
+            WriteElement(document.RootElement, destination);
+        }
+    }
+
+    private static void ValidateNoUnrepresentableNumbers(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var (_, child) in obj)
+                {
+                    if (child is not null)
+                    {
+                        ValidateNoUnrepresentableNumbers(child);
+                    }
+                }
+                break;
+
+            case JsonArray arr:
+                foreach (var item in arr)
+                {
+                    if (item is not null)
+                    {
+                        ValidateNoUnrepresentableNumbers(item);
+                    }
+                }
+                break;
+
+            case JsonValue val:
+                if (val.TryGetValue<double>(out var d))
+                {
+                    if (double.IsNaN(d))
+                    {
+                        throw new JcsFormatException("JCS cannot represent NaN (RFC 8785 §3.2.2.3).");
+                    }
+                    if (double.IsPositiveInfinity(d))
+                    {
+                        throw new JcsFormatException("JCS cannot represent +infinity (RFC 8785 §3.2.2.3).");
+                    }
+                    if (double.IsNegativeInfinity(d))
+                    {
+                        throw new JcsFormatException("JCS cannot represent -infinity (RFC 8785 §3.2.2.3).");
+                    }
+                }
+                else if (val.TryGetValue<float>(out var f))
+                {
+                    if (float.IsNaN(f))
+                    {
+                        throw new JcsFormatException("JCS cannot represent NaN (RFC 8785 §3.2.2.3).");
+                    }
+                    if (float.IsPositiveInfinity(f))
+                    {
+                        throw new JcsFormatException("JCS cannot represent +infinity (RFC 8785 §3.2.2.3).");
+                    }
+                    if (float.IsNegativeInfinity(f))
+                    {
+                        throw new JcsFormatException("JCS cannot represent -infinity (RFC 8785 §3.2.2.3).");
+                    }
+                }
+                break;
+        }
+    }
+
+    private static void WriteElement(JsonElement element, IBufferWriter<byte> writer)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                WriteObject(element, writer);
+                break;
+            case JsonValueKind.Array:
+                WriteArray(element, writer);
+                break;
+            case JsonValueKind.String:
+                WriteString(element.GetString()!, writer);
+                break;
+            case JsonValueKind.Number:
+                WriteNumber(element, writer);
+                break;
+            case JsonValueKind.True:
+                WriteRaw(writer, "true"u8);
+                break;
+            case JsonValueKind.False:
+                WriteRaw(writer, "false"u8);
+                break;
+            case JsonValueKind.Null:
+                WriteRaw(writer, "null"u8);
+                break;
+            case JsonValueKind.Undefined:
+            default:
+                throw new JcsFormatException(
+                    $"JCS cannot canonicalize JSON value of kind '{element.ValueKind}'.");
+        }
+    }
+
+    private static void WriteObject(JsonElement obj, IBufferWriter<byte> writer)
+    {
+        WriteByte(writer, (byte)'{');
+
+        // RFC 8785 §3.2.3: object member names are sorted by UTF-16 code unit order,
+        // which is exactly what string.CompareOrdinal compares.
+        var properties = new List<JsonProperty>();
+        foreach (var prop in obj.EnumerateObject())
+        {
+            properties.Add(prop);
+        }
+
+        properties.Sort(static (a, b) => string.CompareOrdinal(a.Name, b.Name));
+
+        for (var i = 0; i < properties.Count; i++)
+        {
+            if (i > 0)
+            {
+                WriteByte(writer, (byte)',');
+            }
+
+            WriteString(properties[i].Name, writer);
+            WriteByte(writer, (byte)':');
+            WriteElement(properties[i].Value, writer);
+        }
+
+        WriteByte(writer, (byte)'}');
+    }
+
+    private static void WriteArray(JsonElement arr, IBufferWriter<byte> writer)
+    {
+        WriteByte(writer, (byte)'[');
+
+        var first = true;
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (!first)
+            {
+                WriteByte(writer, (byte)',');
+            }
+
+            first = false;
+            WriteElement(item, writer);
+        }
+
+        WriteByte(writer, (byte)']');
+    }
+
+    private static void WriteNumber(JsonElement num, IBufferWriter<byte> writer)
+    {
+        // Signed first: catches negatives. -0 collapses to 0 via long.ToString.
+        if (num.TryGetInt64(out var l))
+        {
+            WriteAscii(writer, l.ToString(CultureInfo.InvariantCulture));
+            return;
+        }
+
+        if (num.TryGetUInt64(out var ul))
+        {
+            WriteAscii(writer, ul.ToString(CultureInfo.InvariantCulture));
+            return;
+        }
+
+        // NaN/±infinity can only appear here if a custom JsonReaderOptions allowed them.
+        if (num.TryGetDouble(out var d))
+        {
+            if (double.IsNaN(d))
+            {
+                throw new JcsFormatException("JCS cannot represent NaN (RFC 8785 §3.2.2.3).");
+            }
+            if (double.IsInfinity(d))
+            {
+                throw new JcsFormatException("JCS cannot represent ±infinity (RFC 8785 §3.2.2.3).");
+            }
+        }
+
+        var raw = num.GetRawText();
+        if (raw.AsSpan().IndexOfAny('.', 'e', 'E') >= 0)
+        {
+            throw new JcsFormatException(
+                "JCS canonicalization of fractional or exponential numbers is not implemented in this version of NetCid. "
+                + "Use integer-valued numbers within [long.MinValue, ulong.MaxValue], or open a follow-up issue if you need IEEE 754 support.");
+        }
+
+        throw new JcsFormatException(
+            $"Integer '{raw}' is outside the supported range [long.MinValue, ulong.MaxValue].");
+    }
+
+    private static void WriteString(string value, IBufferWriter<byte> writer)
+    {
+        WriteByte(writer, (byte)'"');
+
+        // Encode the entire string to UTF-8 once, then walk the bytes. UTF-8 multibyte
+        // continuation bytes all have the high bit set (>= 0x80), so the per-byte escape
+        // table only acts on single-byte ASCII characters — multibyte sequences pass
+        // through verbatim, which is exactly what JCS §3.2.2.2 requires.
+        var maxBytes = Encoding.UTF8.GetMaxByteCount(value.Length);
+
+        byte[]? rented = null;
+        Span<byte> utf8 = maxBytes <= StackBufferThreshold
+            ? stackalloc byte[StackBufferThreshold]
+            : (rented = ArrayPool<byte>.Shared.Rent(maxBytes));
+
+        try
+        {
+            var written = Encoding.UTF8.GetBytes(value, utf8);
+            WriteEscapedUtf8(writer, utf8[..written]);
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        WriteByte(writer, (byte)'"');
+    }
+
+    private static void WriteEscapedUtf8(IBufferWriter<byte> writer, ReadOnlySpan<byte> utf8)
+    {
+        // Walk the UTF-8 bytes and escape only what RFC 8785 §3.2.2.2 strictly requires:
+        // the seven short escapes (\" \\ \b \t \n \f \r) and \u00XX for control bytes
+        // below U+0020. Solidus is NOT escaped. Bytes >= 0x80 are emitted as raw UTF-8.
+        Span<byte> u = stackalloc byte[6] { (byte)'\\', (byte)'u', (byte)'0', (byte)'0', 0, 0 };
+
+        var start = 0;
+        for (var i = 0; i < utf8.Length; i++)
+        {
+            var b = utf8[i];
+
+            ReadOnlySpan<byte> escape;
+            switch (b)
+            {
+                case 0x22: escape = "\\\""u8; break;
+                case 0x5C: escape = "\\\\"u8; break;
+                case 0x08: escape = "\\b"u8; break;
+                case 0x09: escape = "\\t"u8; break;
+                case 0x0A: escape = "\\n"u8; break;
+                case 0x0C: escape = "\\f"u8; break;
+                case 0x0D: escape = "\\r"u8; break;
+                default:
+                    if (b < 0x20)
+                    {
+                        if (i > start)
+                        {
+                            WriteRaw(writer, utf8.Slice(start, i - start));
+                        }
+
+                        u[4] = HexNybble((b >> 4) & 0xF);
+                        u[5] = HexNybble(b & 0xF);
+                        WriteRaw(writer, u);
+                        start = i + 1;
+                    }
+                    continue;
+            }
+
+            if (i > start)
+            {
+                WriteRaw(writer, utf8.Slice(start, i - start));
+            }
+            WriteRaw(writer, escape);
+            start = i + 1;
+        }
+
+        if (start < utf8.Length)
+        {
+            WriteRaw(writer, utf8[start..]);
+        }
+    }
+
+    private static byte HexNybble(int n) => (byte)(n < 10 ? '0' + n : 'a' + (n - 10));
+
+    private static void WriteByte(IBufferWriter<byte> writer, byte b)
+    {
+        var span = writer.GetSpan(1);
+        span[0] = b;
+        writer.Advance(1);
+    }
+
+    private static void WriteRaw(IBufferWriter<byte> writer, ReadOnlySpan<byte> bytes)
+    {
+        var span = writer.GetSpan(bytes.Length);
+        bytes.CopyTo(span);
+        writer.Advance(bytes.Length);
+    }
+
+    private static void WriteAscii(IBufferWriter<byte> writer, string ascii)
+    {
+        var span = writer.GetSpan(ascii.Length);
+        for (var i = 0; i < ascii.Length; i++)
+        {
+            span[i] = (byte)ascii[i];
+        }
+
+        writer.Advance(ascii.Length);
+    }
+}

--- a/NetCid/JcsFormatException.cs
+++ b/NetCid/JcsFormatException.cs
@@ -1,0 +1,18 @@
+namespace NetCid;
+
+/// <summary>
+/// Thrown when a JSON value cannot be canonicalized per RFC 8785
+/// (JSON Canonicalization Scheme).
+/// </summary>
+public sealed class JcsFormatException : FormatException
+{
+    public JcsFormatException(string message)
+        : base(message)
+    {
+    }
+
+    public JcsFormatException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/NetCid/NetCid.csproj
+++ b/NetCid/NetCid.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>NetCid</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Authors>NetCid Contributors</Authors>
     <Description>Multiformats CID implementation for .NET.</Description>
     <PackageTags>cid;multiformats;ipfs;multibase;multicodec;multihash</PackageTags>

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Reference examples are available under `examples/` and mirror the `js-multiforma
 - `examples/block-interface`
 - `examples/multibase-interface`
 - `examples/did-key-interface`
+- `examples/jcs-interface`
 
 See `examples/README.md` for run commands.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - Multicodec constants for common CID codecs (`raw`, `dag-pb`, `dag-cbor`, etc.)
 - Multicodec key-type constants (`ed25519-pub`, `p256-pub`, `secp256k1-pub`, etc.)
 - Multicodec prefix/decode API for varint-tagged byte buffers
+- `JcsCanonicalizer` — RFC 8785 JSON Canonicalization Scheme for stable content-addressing of JSON values, and `Cid.FromCanonicalJson` convenience
 
 ## Install
 
@@ -46,6 +47,14 @@ var cid = Cid.FromContent(content, codec: Multicodec.Raw, hashCode: MultihashCod
 // Serialize
 string text = cid.ToString(); // CIDv1 defaults to base32 lower
 byte[] bytes = cid.ToByteArray();
+
+// Content-address a JSON value with stable bytes (JCS / RFC 8785)
+var entry = new System.Text.Json.Nodes.JsonObject
+{
+    ["seq"] = 1,
+    ["op"]  = "wallet.mint_identity",
+};
+var jsonCid = Cid.FromCanonicalJson(entry);
 ```
 
 ## Specification Notes

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ These examples mirror the `js-multiformats/examples` guide in C# using `NetCid`.
 - `examples/block-interface`: minimal block-style encode/decode/create flow using CID verification
 - `examples/multibase-interface`: multibase encoding comparison across all supported bases including base64url
 - `examples/did-key-interface`: did:key construction using multicodec key-type prefixing and multibase encoding
+- `examples/jcs-interface`: RFC 8785 JSON canonicalization, `Cid.FromCanonicalJson`, the `IBufferWriter<byte>` hot path, and negative cases
 
 ## Run
 
@@ -20,4 +21,5 @@ dotnet run --project examples/multihash-interface/MultihashInterfaceExample.cspr
 dotnet run --project examples/block-interface/BlockInterfaceExample.csproj
 dotnet run --project examples/multibase-interface/MultibaseInterfaceExample.csproj
 dotnet run --project examples/did-key-interface/DidKeyInterfaceExample.csproj
+dotnet run --project examples/jcs-interface/JcsInterfaceExample.csproj
 ```

--- a/examples/jcs-interface/JcsInterfaceExample.csproj
+++ b/examples/jcs-interface/JcsInterfaceExample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\NetCid\NetCid.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/jcs-interface/Program.cs
+++ b/examples/jcs-interface/Program.cs
@@ -1,0 +1,77 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json.Nodes;
+using NetCid;
+
+// 1. Stable serialization — two writers with different key insertion orders
+//    produce identical canonical bytes (RFC 8785).
+var writerA = new JsonObject
+{
+    ["seq"]         = 1,
+    ["op"]          = "wallet.mint_identity",
+    ["identity_id"] = "id_42",
+    ["params_hash"] = "bafyparams",
+    ["prev_cid"]    = "genesis",
+};
+
+var writerB = new JsonObject
+{
+    ["prev_cid"]    = "genesis",
+    ["params_hash"] = "bafyparams",
+    ["identity_id"] = "id_42",
+    ["op"]          = "wallet.mint_identity",
+    ["seq"]         = 1,
+};
+
+var canonicalA = JcsCanonicalizer.Canonicalize(writerA);
+var canonicalB = JcsCanonicalizer.Canonicalize(writerB);
+
+Console.WriteLine("== Stable serialization ==");
+Console.WriteLine($"writer A canonical: {Encoding.UTF8.GetString(canonicalA)}");
+Console.WriteLine($"writer B canonical: {Encoding.UTF8.GetString(canonicalB)}");
+Console.WriteLine($"bytes equal:        {canonicalA.AsSpan().SequenceEqual(canonicalB)}");
+Console.WriteLine();
+
+// 2. JCS → CID in one call. Use Cid.FromCanonicalJson for the common case.
+var entryCid = Cid.FromCanonicalJson(writerA);
+Console.WriteLine("== JCS -> CID (one-shot) ==");
+Console.WriteLine($"Cid.FromCanonicalJson: {entryCid}");
+Console.WriteLine();
+
+// 3. Two-step path for pipelines that need the canonical bytes for signing.
+//    Hand the bytes to your signing key or hash primitive of choice.
+var bytesForSigning = JcsCanonicalizer.Canonicalize(writerA);
+Console.WriteLine("== Two-step (canonicalize -> sign) ==");
+Console.WriteLine($"bytes ready for external signer: {bytesForSigning.Length} bytes");
+Console.WriteLine();
+
+// 4. Zero-allocation hot path for audit-chain verify, where the same canonical
+//    bytes are hashed and compared per entry. Write directly into an
+//    IBufferWriter<byte> and reuse the buffer.
+Console.WriteLine("== Zero-allocation IBufferWriter overload ==");
+var pooled = new ArrayBufferWriter<byte>(initialCapacity: 256);
+JcsCanonicalizer.Canonicalize(writerA, pooled);
+var pooledCid = Cid.FromContent(pooled.WrittenSpan);
+Console.WriteLine($"written: {pooled.WrittenCount} bytes  cid: {pooledCid}");
+Console.WriteLine();
+
+// 5. Negative cases — JCS cannot represent NaN or fractional numbers in v1.
+//    JcsFormatException carries an actionable message.
+Console.WriteLine("== Negative cases ==");
+try
+{
+    JcsCanonicalizer.Canonicalize(JsonValue.Create(double.NaN));
+}
+catch (JcsFormatException ex)
+{
+    Console.WriteLine($"NaN rejected:        {ex.Message}");
+}
+
+try
+{
+    JcsCanonicalizer.Canonicalize(JsonNode.Parse("1.5"));
+}
+catch (JcsFormatException ex)
+{
+    Console.WriteLine($"fractional rejected: {ex.Message}");
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,3 +4,7 @@
 
 - When a user asks to "fix all findings" from a security report, do not stop at recommendations. Resolve each finding in code/dependencies, re-run security commands, and update the report status to resolved.
 - When the user references an external examples guide, inspect that guide directly and mirror its example taxonomy in the local `examples/` directory.
+
+## 2026-05-21
+
+- AGENTS.md "Plan First / Verify Plan" is non-negotiable. Write the plan to `tasks/todo.md` and report it to the user for verification **before** any implementation or file write — even when the issue body looks self-explanatory and the autonomous-bug-fixing principle would otherwise apply. Implementation-first is a correction-worthy violation.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -362,18 +362,53 @@
 
 ## Plan
 
-- [ ] Read issue `#9` requirements and current branch state.
-- [ ] Inspect the JCS implementation, CID convenience API, tests, and release notes on this branch.
-- [ ] Run focused verification for the implementation under review.
-- [ ] Record the validation result and any residual gaps in this review section.
+- [x] Read issue `#9` requirements and current branch state.
+- [x] Inspect the JCS implementation, CID convenience API, tests, and release notes on this branch.
+- [x] Run focused verification for the implementation under review.
+- [x] Record the validation result and any residual gaps in this review section.
 
 ## Verification Checklist
 
-- [ ] Inspect `NetCid/JcsCanonicalizer.cs`, `NetCid/JcsFormatException.cs`, and `NetCid/Cid.cs`
-- [ ] Inspect JCS unit and integration tests
-- [ ] Inspect package/version and changelog evidence
-- [ ] Run focused build/test commands for JCS coverage
+- [x] Inspect `NetCid/JcsCanonicalizer.cs`, `NetCid/JcsFormatException.cs`, and `NetCid/Cid.cs`
+- [x] Inspect JCS unit and integration tests
+- [x] Inspect package/version and changelog evidence
+- [x] Run focused build/test commands for JCS coverage
 
 ## Review
 
-- Pending
+- Verdict: issue `#9` is addressed on `feature/jcs-canonicalization`. The branch adds the requested `JcsCanonicalizer` overloads, `JcsFormatException`, `Cid.FromCanonicalJson`, JCS unit coverage, CID integration coverage, README guidance, changelog entry, and package version bump to `1.4.0`.
+- Scope note: the branch follows issue `#9`'s recommended v1 option for numbers: integer-valued JSON numbers are supported while fractional/exponential IEEE 754 formatting is rejected with `JcsFormatException` and left for a follow-up.
+- Branch state checked: GitHub issue `#9` is still open, while this branch is ahead of `main` with the JCS commit already present.
+- Verification completed:
+  - `dotnet build NetCid/NetCid.csproj -c Release --no-restore --tl:off` succeeded with 0 warnings and 0 errors.
+  - `dotnet test NetCid.Tests/NetCid.Tests.csproj -c Release --no-build --no-restore --filter FullyQualifiedName~JcsCanonicalizerTests --tl:off` passed 30/30.
+  - `dotnet test NetCid.IntegrationTests/NetCid.IntegrationTests.csproj -c Release --no-build --no-restore --filter FullyQualifiedName~JcsCidRoundTripTests --tl:off` passed 3/3.
+  - `dotnet test NetCid.Tests/NetCid.Tests.csproj -c Release --no-build --no-restore --tl:off` passed 105/105.
+  - `dotnet test NetCid.IntegrationTests/NetCid.IntegrationTests.csproj -c Release --no-build --no-restore --tl:off` passed 6/6.
+- Verification caveat: `dotnet build NetCid.sln -c Release --tl:off` and its `--no-restore` variant stalled in this environment after emitting library output, so those solution-level build attempts were stopped rather than recorded as successful.
+
+---
+
+# Follow-up: JCS example (Issue #9 / PR #10) — COMPLETED
+
+## Scope
+
+- Add a runnable example mirroring the existing `examples/*-interface/` taxonomy so consumers can see the JCS surface end-to-end alongside the other multiformats interfaces.
+
+## Plan
+
+- [x] Add `examples/jcs-interface/JcsInterfaceExample.csproj` + `Program.cs` walking through stable serialization, `Cid.FromCanonicalJson`, two-step canonicalize-then-sign, the `IBufferWriter<byte>` hot path, and the `JcsFormatException` negative cases.
+- [x] Register the project in `NetCid.sln`.
+- [x] Add `jcs-interface` entry to `examples/README.md` and the main `README.md` example list.
+- [x] Verify with `dotnet build` and `dotnet run --no-build` on the new example.
+
+## Verification Checklist
+
+- [x] `dotnet build examples/jcs-interface/JcsInterfaceExample.csproj -c Release --tl:off` — 0 warnings, 0 errors
+- [x] `dotnet build NetCid.sln -c Release --tl:off` — 0 warnings, 0 errors
+- [x] `dotnet run --project examples/jcs-interface/JcsInterfaceExample.csproj -c Release --no-build --tl:off` prints all five sections; the `Cid.FromCanonicalJson` and `IBufferWriter<byte>` paths emit the same CID
+- [x] Full unit/integration suites still pass (105/105 unit, 6/6 integration)
+
+## Review
+
+- Example bundled into PR #10 per request so reviewers see the user-facing surface alongside the implementation.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -299,3 +299,54 @@
 ## Review
 
 - Pending
+
+---
+
+# Task: Add JCS (RFC 8785) JSON canonicalization (Issue #9) — COMPLETED
+
+## Scope
+
+- Implement JSON Canonicalization Scheme (RFC 8785) so consumers can content-address JSON values with stable byte output and pair naturally with `Cid.FromContent`.
+- Add a `JcsCanonicalizer` static class with three overloads (`JsonNode?`, `JsonElement`, and `JsonNode? + IBufferWriter<byte>`).
+- Add `JcsFormatException : FormatException` for JCS-specific errors.
+- Add `Cid.FromCanonicalJson(JsonNode?, codec, hashCode)` convenience overload that canonicalizes + builds a CID in one call.
+- Bump package version to `1.4.0` and document the addition.
+
+## v1 type-coverage decision (matches the issue's recommendation **b**)
+
+- Supported: objects (sorted-key), arrays (order-preserved), strings (RFC 8785 §3.2.2.2 escapes, raw UTF-8 above U+007F), integer numbers within `[long.MinValue, ulong.MaxValue]`, `true`, `false`, `null`.
+- Throws `JcsFormatException`: fractional / exponential numbers, `NaN`, `±∞`, integers outside `[long.MinValue, ulong.MaxValue]`, `JsonValueKind.Undefined`.
+- Rationale: every consumer named in the issue (wallet audit log, ZCAP-LD `zcap_cid`, VC DataIntegrity proofs over JCS) only needs integers + strings + bools + objects + arrays. ECMAScript-style fractional output is deferred to a follow-up issue.
+
+## Implementation strategy
+
+- `JsonElement` walker is the single source of truth for writing canonical bytes — sorts object keys by `string.CompareOrdinal` (UTF-16 code unit order = JCS §3.2.3), preserves array order, writes numbers from `TryGetInt64` / `TryGetUInt64`, and emits strings via UTF-8 with byte-level escape pass (`\"`, `\\`, `\b`, `\t`, `\n`, `\f`, `\r`, `\u00XX` for U+0000..U+001F). All bytes ≥ 0x80 pass through as raw UTF-8.
+- `JsonNode?` overloads pre-walk to catch NaN/±∞ stored as raw .NET doubles (the System.Text.Json serializer would otherwise throw a generic `JsonException`), then `JsonSerializer.SerializeToDocument` into a `JsonDocument` and delegate to the `JsonElement` walker.
+- `IBufferWriter<byte>` overload writes directly to the writer with `stackalloc`-backed UTF-8 staging for small strings and `ArrayPool<byte>` fallback for large ones, avoiding per-call `byte[]` allocation in hot paths (audit chain verification).
+- `-0` normalises to `0` (parsed as integer by `TryGetInt64`, formatted back via `ToString(CultureInfo.InvariantCulture)`).
+
+## Plan
+
+- [x] Add `NetCid/JcsFormatException.cs`.
+- [x] Add `NetCid/JcsCanonicalizer.cs` with the three public overloads + private walker helpers.
+- [x] Add `Cid.FromCanonicalJson` overload in `NetCid/Cid.cs`.
+- [x] Add `NetCid.Tests/JcsCanonicalizerTests.cs` (30 tests).
+- [x] Add `NetCid.IntegrationTests/JcsCidRoundTripTests.cs` (3 tests).
+- [x] Bump `Version` to `1.4.0` in `NetCid/NetCid.csproj`.
+- [x] Add a `1.4.0` entry in `CHANGELOG.md` referencing issue #9.
+- [x] Add a JCS bullet + usage snippet to README.
+
+## Verification Checklist
+
+- [x] `dotnet build NetCid.sln -c Release --tl:off` — 0 warnings, 0 errors
+- [x] `dotnet test NetCid.Tests/NetCid.Tests.csproj -c Release --no-build` — 105/105 pass (75 prior + 30 new)
+- [x] `dotnet test NetCid.IntegrationTests/NetCid.IntegrationTests.csproj -c Release --no-build` — 6/6 pass (3 prior + 3 new)
+
+## Review
+
+- Implemented `JcsCanonicalizer` with a `JsonElement` walker as the canonical core. `JsonNode` overloads pre-validate raw .NET `NaN`/`±∞` doubles (which `JsonSerializer.SerializeToDocument` otherwise rejects with a generic `JsonException`), then serialize to a `JsonDocument` and delegate to the same walker — keeping one well-tested code path for canonical bytes.
+- Object key sort uses `string.CompareOrdinal` (UTF-16 code unit ordering, identical to RFC 8785 §3.2.3). Integers go through `TryGetInt64`/`TryGetUInt64`, formatted with `InvariantCulture`; this auto-normalises `-0` to `0` and covers the full `[long.MinValue, ulong.MaxValue]` range used by audit chains.
+- String escaper UTF-8-encodes the whole string into a stackalloc / `ArrayPool<byte>` buffer (256-byte cutoff), then byte-walks: only the seven short escapes plus `\u00XX` for bytes `< 0x20` need replacement. Bytes `>= 0x80` (all UTF-8 multi-byte continuations and lead bytes) pass through as raw bytes, which matches JCS §3.2.2.2's requirement that characters above U+007F stay as raw UTF-8 — verified with the `é` and emoji surrogate-pair tests.
+- Added `Cid.FromCanonicalJson(JsonNode?, codec = Raw, hashCode = Sha2_256)` that writes canonical bytes straight into an `ArrayBufferWriter<byte>` and feeds the resulting span to `FromContent`, avoiding an intermediate `byte[]`. The round-trip integration test proves it produces the same `Cid` as the two-step `FromContent(JcsCanonicalizer.Canonicalize(...))` form.
+- v1 type scope deliberately throws `JcsFormatException` for fractional/exponential numbers, `NaN`, `±∞`, oversized integers, and `JsonValueKind.Undefined`. Each exception message is actionable (range hint or follow-up pointer) so a downstream consumer hitting it knows exactly why.
+- Verified locally: full release build clean (0 warnings, 0 errors); 105 unit + 6 integration tests green.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -350,3 +350,30 @@
 - Added `Cid.FromCanonicalJson(JsonNode?, codec = Raw, hashCode = Sha2_256)` that writes canonical bytes straight into an `ArrayBufferWriter<byte>` and feeds the resulting span to `FromContent`, avoiding an intermediate `byte[]`. The round-trip integration test proves it produces the same `Cid` as the two-step `FromContent(JcsCanonicalizer.Canonicalize(...))` form.
 - v1 type scope deliberately throws `JcsFormatException` for fractional/exponential numbers, `NaN`, `±∞`, oversized integers, and `JsonValueKind.Undefined`. Each exception message is actionable (range hint or follow-up pointer) so a downstream consumer hitting it knows exactly why.
 - Verified locally: full release build clean (0 warnings, 0 errors); 105 unit + 6 integration tests green.
+
+---
+
+# Task: Validate Issue #9 on Current Branch
+
+## Scope
+
+- Compare the current branch against GitHub issue `#9` for JCS canonicalization.
+- Validate the public API, tests, documentation/version notes, and branch verification evidence before deciding whether the issue is addressed.
+
+## Plan
+
+- [ ] Read issue `#9` requirements and current branch state.
+- [ ] Inspect the JCS implementation, CID convenience API, tests, and release notes on this branch.
+- [ ] Run focused verification for the implementation under review.
+- [ ] Record the validation result and any residual gaps in this review section.
+
+## Verification Checklist
+
+- [ ] Inspect `NetCid/JcsCanonicalizer.cs`, `NetCid/JcsFormatException.cs`, and `NetCid/Cid.cs`
+- [ ] Inspect JCS unit and integration tests
+- [ ] Inspect package/version and changelog evidence
+- [ ] Run focused build/test commands for JCS coverage
+
+## Review
+
+- Pending


### PR DESCRIPTION
Closes #9.

## Summary

- New `JcsCanonicalizer` static class implementing RFC 8785 (JSON Canonicalization Scheme) — overloads for `JsonNode?`, `JsonElement`, and `IBufferWriter<byte>` so audit/verify hot paths can avoid intermediate `byte[]` allocation.
- New `Cid.FromCanonicalJson(JsonNode?, codec, hashCode)` convenience pairing — canonicalize + `FromContent` in one call.
- New `JcsFormatException : FormatException` for JCS-specific failures with actionable messages (range hint or follow-up pointer).

## v1 scope (issue option **b**)

- Supported: objects (sorted by `string.CompareOrdinal` = UTF-16 code unit order, RFC 8785 §3.2.3), arrays (order preserved), strings (RFC 8785 §3.2.2.2 escapes + raw UTF-8 for ≥ U+0080), integer numbers within `[long.MinValue, ulong.MaxValue]` (`-0` collapses to `0`), `true` / `false` / `null`.
- Throws `JcsFormatException`: fractional / exponential numbers, `NaN`, `±∞`, integers outside `[long.MinValue, ulong.MaxValue]`, `JsonValueKind.Undefined`.
- Every consumer named in #9 (wallet audit log, ZCAP-LD `zcap_cid`, VC DataIntegrity proofs) only needs the supported set; ECMAScript-style fractional output is deferred to a follow-up.

## Implementation highlights

- `JsonElement` walker is the single source of truth for canonical bytes.
- `JsonNode?` overloads pre-validate raw .NET `NaN`/`±∞` doubles (which `JsonSerializer.SerializeToDocument` otherwise rejects with a generic `JsonException`), then serialize to a `JsonDocument` and delegate to the walker.
- String escaper UTF-8-encodes once (`stackalloc` ≤256 bytes / `ArrayPool<byte>` above), then byte-walks: only the seven short escapes and `\u00XX` for bytes `< 0x20` are replaced. Bytes `≥ 0x80` pass through as raw UTF-8 (verified with `é` and an emoji surrogate-pair test).

## Verification

- `dotnet build NetCid.sln -c Release` — 0 warnings, 0 errors.
- `dotnet test NetCid.Tests` — 105/105 (75 prior + **30 new**).
- `dotnet test NetCid.IntegrationTests` — 6/6 (3 prior + **3 new**).

## Test plan

- [x] RFC 8785 key-sort vectors (pure ASCII, mixed case, nested)
- [x] Seven short escapes + `\u0001` / `\u001F` control bytes
- [x] Raw UTF-8 preservation for `é` and surrogate-pair emoji
- [x] Solidus `/` is not escaped
- [x] `-0` → `0`; full `[long.MinValue, ulong.MaxValue]` range
- [x] Idempotence: `Canonicalize(Parse(Canonicalize(x))) == Canonicalize(x)`
- [x] `IBufferWriter<byte>` overload equivalence + null-destination rejection
- [x] `JsonElement` ↔ `JsonNode` overload parity
- [x] Negative cases: `NaN`, `±∞`, fractional, exponential, out-of-range integer
- [x] Integration: `Cid.FromCanonicalJson` equals two-step `FromContent(Canonicalize(...))`
- [x] Integration: two writers with different key insertion orders produce identical CIDs
- [x] Integration: custom codec + SHA-512 honoured

## Package metadata

- Version bumped to `1.4.0`; `CHANGELOG.md` and `README.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)