### PR TITLE
Add Multicodec.P521Pub (0x1202) for NIST P-521 (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [1.5.0] - 2026-05-22
+
+### Added
+
+- `Multicodec.P521Pub` (`0x1202`) and the `"p521-pub"` name mapping, completing the NIST P-curve public-key set alongside the existing `P256Pub` / `P384Pub` ([#11](https://github.com/moisesja/net-cid/issues/11))
+
 ## [1.4.0] - 2026-05-21
 
 ### Added
@@ -56,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SHA-256 and SHA-512 multihash support
 - Core multicodec constants (raw, dag-pb, dag-cbor, etc.)
 
-[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/moisesja/net-cid/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/moisesja/net-cid/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/moisesja/net-cid/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/moisesja/net-cid/compare/v1.2.0...v1.2.1

--- a/NetCid.Tests/MulticodecTests.cs
+++ b/NetCid.Tests/MulticodecTests.cs
@@ -10,6 +10,7 @@ public sealed class MulticodecTests
     [InlineData(Multicodec.Ed25519Pub, "ed25519-pub")]
     [InlineData(Multicodec.P256Pub, "p256-pub")]
     [InlineData(Multicodec.P384Pub, "p384-pub")]
+    [InlineData(Multicodec.P521Pub, "p521-pub")]
     public void TryGetName_ReturnsNameForKeyType(ulong code, string expectedName)
     {
         Assert.True(Multicodec.TryGetName(code, out var name));
@@ -24,6 +25,7 @@ public sealed class MulticodecTests
     [InlineData("ed25519-pub", Multicodec.Ed25519Pub)]
     [InlineData("p256-pub", Multicodec.P256Pub)]
     [InlineData("p384-pub", Multicodec.P384Pub)]
+    [InlineData("p521-pub", Multicodec.P521Pub)]
     public void TryGetCode_ReturnsCodeForKeyType(string name, ulong expectedCode)
     {
         Assert.True(Multicodec.TryGetCode(name, out var code));
@@ -59,6 +61,7 @@ public sealed class MulticodecTests
     [InlineData(Multicodec.Ed25519Pub)]
     [InlineData(Multicodec.P256Pub)]
     [InlineData(Multicodec.P384Pub)]
+    [InlineData(Multicodec.P521Pub)]
     public void PrefixDecode_RoundTrip(ulong codec)
     {
         var rawBytes = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };

--- a/NetCid/Multicodec.cs
+++ b/NetCid/Multicodec.cs
@@ -39,6 +39,7 @@ public static class Multicodec
     public const ulong Ed25519Pub = 0xED;
     public const ulong P256Pub = 0x1200;
     public const ulong P384Pub = 0x1201;
+    public const ulong P521Pub = 0x1202;
 
     private static readonly IReadOnlyDictionary<ulong, string> NamesByCode = new ReadOnlyDictionary<ulong, string>(
         new Dictionary<ulong, string>
@@ -72,7 +73,8 @@ public static class Multicodec
             [X25519Pub] = "x25519-pub",
             [Ed25519Pub] = "ed25519-pub",
             [P256Pub] = "p256-pub",
-            [P384Pub] = "p384-pub"
+            [P384Pub] = "p384-pub",
+            [P521Pub] = "p521-pub"
         });
 
     private static readonly IReadOnlyDictionary<string, ulong> CodesByName = new ReadOnlyDictionary<string, ulong>(

--- a/NetCid/NetCid.csproj
+++ b/NetCid/NetCid.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>NetCid</PackageId>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <Authors>NetCid Contributors</Authors>
     <Description>Multiformats CID implementation for .NET.</Description>
     <PackageTags>cid;multiformats;ipfs;multibase;multicodec;multihash</PackageTags>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -412,3 +412,38 @@
 ## Review
 
 - Example bundled into PR #10 per request so reviewers see the user-facing surface alongside the implementation.
+
+---
+
+# Task: Add P-521 (P521Pub = 0x1202) multicodec constant (Issue #11) — COMPLETED
+
+## Scope
+
+- Add the `Multicodec.P521Pub = 0x1202` constant and `"p521-pub"` name mapping so .NET SSI consumers (notably `net-did` PR #66) don't have to redeclare it locally. Purely additive — no breaking change.
+
+## Plan
+
+- [x] Branch `feature/issue-11-p521-multicodec` off `origin/main`.
+- [x] `NetCid/Multicodec.cs`: add `public const ulong P521Pub = 0x1202;` after `P384Pub`, and `[P521Pub] = "p521-pub"` after the `P384Pub` row in `NamesByCode`.
+- [x] `NetCid.Tests/MulticodecTests.cs`: add `Multicodec.P521Pub` rows to the `TryGetName_ReturnsNameForKeyType`, `TryGetCode_ReturnsCodeForKeyType`, and `PrefixDecode_RoundTrip` theories.
+- [x] `NetCid/NetCid.csproj`: bump `<Version>` from `1.4.0` → `1.5.0`.
+- [x] `CHANGELOG.md`: add `## [1.5.0] - 2026-05-22` entry + link footer.
+- [x] Run `dotnet build NetCid.sln -c Release` and `dotnet test` (unit + integration).
+
+## Verification Checklist
+
+- [x] `dotnet build NetCid.sln -c Release --tl:off` — 0 warnings, 0 errors
+- [x] `dotnet test NetCid.Tests/NetCid.Tests.csproj -c Release --no-build --tl:off` — 108/108 (105 prior + 3 new theory rows)
+- [x] `dotnet test NetCid.IntegrationTests/NetCid.IntegrationTests.csproj -c Release --no-build --tl:off` — 6/6
+- [x] Varint encoding for `0x1202` confirmed `[0x82, 0x24]` via the `PrefixDecode_RoundTrip` theory.
+
+## Branching note
+
+- PR #10 (JCS / 1.4.0) was merged before this task started (commit `b65fb7f`), so this branch off `origin/main` already carries the 1.4.0 changelog entry. No version-bump conflict.
+
+## Review
+
+- Added `P521Pub = 0x1202` in registry order after `P384Pub`, and `"p521-pub"` to `NamesByCode`. No other code paths touched.
+- Theory coverage for `TryGetName`, `TryGetCode`, and `PrefixDecode_RoundTrip` grew by one inline row each — three additional test cases, no new test methods. `PrefixDecode_RoundTrip(Multicodec.P521Pub)` exercises the `[0x82, 0x24]` varint round-trip via the existing `Multicodec.Prefix` / `Multicodec.Decode` path, so no per-codec varint assertion was needed beyond what's already in place.
+- Version bumped 1.4.0 → 1.5.0 with `## [1.5.0] - 2026-05-22` entry referencing #11. Matches the 1.3.0 / 1.4.0 additive-minor precedent.
+- 108/108 unit + 6/6 integration tests pass; build clean (0 warnings, 0 errors).


### PR DESCRIPTION
Closes #11.

## Summary

- Add `public const ulong P521Pub = 0x1202;` to `Multicodec`, completing the NIST P-curve public-key set alongside the existing `P256Pub` (`0x1200`) and `P384Pub` (`0x1201`).
- Register `\"p521-pub\"` in `NamesByCode` so `TryGetName` / `TryGetCode` resolve symmetrically with the other key-type codecs.
- Bumps to **1.5.0** per the additive-minor precedent established by 1.3.0 (`Multihash.Encode`) and 1.4.0 (JCS).
- Unblocks [net-did PR #66](https://github.com/moisesja/net-did/pull/66) — `KeyTypeExtensions.cs` currently shims `P521PubMulticodec = 0x1202` locally; after this lands it can read from `Multicodec.P521Pub` like every other curve.

## Diff scope

- `NetCid/Multicodec.cs` — one constant line, one `NamesByCode` entry, registry order preserved.
- `NetCid.Tests/MulticodecTests.cs` — one `[InlineData]` row added to each of three existing theories (`TryGetName_ReturnsNameForKeyType`, `TryGetCode_ReturnsCodeForKeyType`, `PrefixDecode_RoundTrip`); no new test methods.
- `NetCid/NetCid.csproj` — `<Version>` `1.4.0` → `1.5.0`.
- `CHANGELOG.md` — new `## [1.5.0] - 2026-05-22` entry + link footer.

## Verification

- `dotnet build NetCid.sln -c Release --tl:off` — 0 warnings, 0 errors.
- `dotnet test NetCid.Tests` — **108/108** pass (105 prior + 3 new theory rows).
- `dotnet test NetCid.IntegrationTests` — 6/6 pass.
- `PrefixDecode_RoundTrip(Multicodec.P521Pub)` exercises the expected varint `[0x82, 0x24]` round-trip end-to-end (`4610 & 0x7F = 0x02 | 0x80 = 0x82`; `4610 >> 7 = 36 = 0x24`).

## Acceptance criteria from the issue

- [x] `Multicodec.P521Pub` is `public const ulong` with value `0x1202`
- [x] `Multicodec.TryGetName(0x1202, out var n)` returns `true` with `n == \"p521-pub\"`
- [x] `Multicodec.TryGetCode(\"p521-pub\", out var c)` returns `true` with `c == 0x1202`
- [x] `Prefix → Decode` round-trip passes for P-521
- [x] CHANGELOG entry under `## [1.5.0]`
- [x] `<Version>` bumped to `1.5.0`

## Out of scope (per issue)

- `p521-priv` and other private-key codecs.
- Curve448, brainpool, and other non-NIST curves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)