### PR TITLE
Add Multikey codec for W3C publicKeyMultibase / did:key (#14)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,7 @@ The library also serves as a shared foundation for higher-level protocols that d
 | `MultihashCode` | `NetCid/MultihashCode.cs` | Constants for hash function identifiers (SHA-256 = `0x12`, SHA-512 = `0x13`, etc.). |
 | `MultihashDigest` | `NetCid/MultihashDigest.cs` | Immutable model representing a multihash: `[varint(code)][varint(digestLength)][digest]`. Provides `Sha2_256()` and `Sha2_512()` factory methods. |
 | `Multicodec` | `NetCid/Multicodec.cs` | Constants for content-type codecs (dag-pb, raw, etc.) and key-type codecs (ed25519-pub, p256-pub, etc.). Bidirectional name/code lookup table. `Prefix()` / `Decode()` / `TryDecode()` API for varint-tagging arbitrary byte buffers. |
+| `Multikey` | `NetCid/Multikey.cs` | W3C Controlled Identifiers Multikey / `did:key` `publicKeyMultibase` helpers. `Encode()` / `Decode()` / `TryDecode()` compose `Multicodec.Prefix` + `Multibase` (base58btc, strict) and add per-codec raw-key-length validation for the eight supported public-key codecs. |
 | `MultibaseEncoding` | `NetCid/MultibaseEncoding.cs` | Enum of supported base encodings. |
 | `Multibase` | `NetCid/Multibase.cs` | Encodes byte arrays to multibase-prefixed strings and decodes them back. Supports base32, base36, base58btc, and base64url. Auto-detects encoding from the single-character prefix on decode. |
 | `CidVersion` | `NetCid/CidVersion.cs` | Enum: `V0`, `V1`. |
@@ -106,6 +107,11 @@ Multibase.Encode(prefixed, Base58Btc) ← "z" + base58btc-encoded
     ▼
 "did:key:z..."                        ← full did:key identifier
 ```
+
+`Multikey.Encode(Ed25519Pub, rawKey)` is the one-call equivalent of the
+two middle steps — it also validates the codec is one of the eight
+supported key types and that `rawKey.Length` matches that codec, so DID
+consumers get a single API instead of hand-assembling the prefix.
 
 ## Design Decisions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Multikey` static class (`Encode` / `Decode` / `TryDecode`) implementing the W3C Controlled Identifiers 1.0 Multikey verification method and `did:key` `publicKeyMultibase` encoding: `base58btc( varint(keyCodec) ‖ rawPublicKey )`. Validates that the codec is one of the eight supported key-type multicodecs (`ed25519-pub`, `x25519-pub`, `secp256k1-pub`, `p256-pub`, `p384-pub`, `p521-pub`, `bls12_381-g1-pub`, `bls12_381-g2-pub`) and that the raw key length matches that codec; rejects non-base58btc multibases and content-type codecs ([#14](https://github.com/moisesja/net-cid/issues/14))
 - Full RFC 8785 §3.2.2.3 / ECMA-262 §6.1.6.1.20 (`Number.prototype.toString`) support in `JcsCanonicalizer` — JSON values containing fractional, exponential, or out-of-`ulong` numbers (monetary amounts, geo coordinates, scores in Verifiable Credentials) now canonicalize, resolving the v1 follow-up tracked from 1.4.0 ([#13](https://github.com/moisesja/net-cid/issues/13))
 - Internal `EcmaScriptNumber.ToCanonicalString(double)` helper implementing the ECMA-262 §6.1.6.1.20 algorithm against .NET's shortest-round-trip digit string
 - `jcs-number-conformance` workflow that downloads and (when `CONFORMANCE_EXPECTED_SHA256` is set) SHA-256-verifies cyberphone's `es6testfile100m.txt.gz` (100M-vector RFC 8785 conformance set) and runs it on PRs that touch the number formatter, plus `workflow_dispatch` and a weekly backstop. The SHA-256 pin is empty at merge time and tracked as a follow-up

--- a/NetCid.Tests/MultikeyTests.cs
+++ b/NetCid.Tests/MultikeyTests.cs
@@ -1,0 +1,168 @@
+namespace NetCid.Tests;
+
+public sealed class MultikeyTests
+{
+    public static TheoryData<ulong, int> KeyCodecsAndLengths => new()
+    {
+        { Multicodec.Ed25519Pub, 32 },
+        { Multicodec.X25519Pub, 32 },
+        { Multicodec.Secp256k1Pub, 33 },
+        { Multicodec.P256Pub, 33 },
+        { Multicodec.P384Pub, 49 },
+        { Multicodec.P521Pub, 67 },
+        { Multicodec.Bls12381G1Pub, 48 },
+        { Multicodec.Bls12381G2Pub, 96 },
+    };
+
+    [Theory]
+    [MemberData(nameof(KeyCodecsAndLengths))]
+    public void Encode_Decode_RoundTrips_ForEveryKeyCodec(ulong codec, int expectedLength)
+    {
+        var rawKey = DeterministicKey(expectedLength);
+
+        var multibase = Multikey.Encode(codec, rawKey);
+
+        Assert.StartsWith("z", multibase, StringComparison.Ordinal);
+
+        var (decodedCodec, decodedKey) = Multikey.Decode(multibase);
+        Assert.Equal(codec, decodedCodec);
+        Assert.Equal(rawKey, decodedKey);
+    }
+
+    [Theory]
+    [MemberData(nameof(KeyCodecsAndLengths))]
+    public void TryDecode_Returns_True_ForRoundTrippedEncoding(ulong codec, int expectedLength)
+    {
+        var rawKey = DeterministicKey(expectedLength);
+        var multibase = Multikey.Encode(codec, rawKey);
+
+        Assert.True(Multikey.TryDecode(multibase, out var decodedCodec, out var decodedKey));
+        Assert.Equal(codec, decodedCodec);
+        Assert.Equal(rawKey, decodedKey);
+    }
+
+    [Fact]
+    public void Encode_Throws_OnUnknownCodec()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => Multikey.Encode(Multicodec.Raw, new byte[32]));
+
+        Assert.Equal("keyCodec", ex.ParamName);
+    }
+
+    [Fact]
+    public void Encode_Throws_OnContentCodecDagPb()
+    {
+        Assert.Throws<ArgumentException>(
+            () => Multikey.Encode(Multicodec.DagPb, new byte[32]));
+    }
+
+    [Theory]
+    [MemberData(nameof(KeyCodecsAndLengths))]
+    public void Encode_Throws_OnWrongKeyLength(ulong codec, int expectedLength)
+    {
+        var wrong = new byte[expectedLength + 1];
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => Multikey.Encode(codec, wrong));
+
+        Assert.Equal("rawKey", ex.ParamName);
+    }
+
+    [Fact]
+    public void TryDecode_Returns_False_OnWrongLengthPayload()
+    {
+        // Build base58btc(varint(Ed25519Pub) || 16-byte payload) — codec is valid, length is not.
+        var prefixed = Multicodec.Prefix(Multicodec.Ed25519Pub, new byte[16]);
+        var multibase = Multibase.Encode(prefixed, MultibaseEncoding.Base58Btc, includePrefix: true);
+
+        Assert.False(Multikey.TryDecode(multibase, out var codec, out var raw));
+        Assert.Equal(0UL, codec);
+        Assert.Null(raw);
+    }
+
+    [Fact]
+    public void TryDecode_Returns_False_OnNonBase58Multibase()
+    {
+        // Same prefixed bytes, but encoded as base32 ('b' prefix) instead of base58btc.
+        var prefixed = Multicodec.Prefix(Multicodec.Ed25519Pub, DeterministicKey(32));
+        var base32 = Multibase.Encode(prefixed, MultibaseEncoding.Base32Lower, includePrefix: true);
+
+        Assert.False(Multikey.TryDecode(base32, out _, out _));
+    }
+
+    [Fact]
+    public void TryDecode_Returns_False_OnBase64UrlMultibase()
+    {
+        // Multikey is base58btc only — base64url ('u') must be rejected even with a valid key payload.
+        var prefixed = Multicodec.Prefix(Multicodec.Ed25519Pub, DeterministicKey(32));
+        var base64url = Multibase.Encode(prefixed, MultibaseEncoding.Base64Url, includePrefix: true);
+
+        Assert.False(Multikey.TryDecode(base64url, out _, out _));
+    }
+
+    [Fact]
+    public void TryDecode_Returns_False_OnContentCodecPrefix()
+    {
+        // Multicodec.Raw (0x55) is a content codec, not a key type. Reject even with a 32-byte payload.
+        var prefixed = Multicodec.Prefix(Multicodec.Raw, DeterministicKey(32));
+        var multibase = Multibase.Encode(prefixed, MultibaseEncoding.Base58Btc, includePrefix: true);
+
+        Assert.False(Multikey.TryDecode(multibase, out _, out _));
+    }
+
+    [Fact]
+    public void TryDecode_Returns_False_OnEmptyOrNullInput()
+    {
+        Assert.False(Multikey.TryDecode(string.Empty, out _, out _));
+        Assert.False(Multikey.TryDecode(null!, out _, out _));
+    }
+
+    [Fact]
+    public void Decode_Throws_CidFormatException_OnInvalidInput()
+    {
+        Assert.Throws<CidFormatException>(() => Multikey.Decode("not-a-multikey"));
+    }
+
+    [Fact]
+    public void Encode_ProducesMultikeySignaturePrefix_ForEd25519()
+    {
+        // Every 32-byte Ed25519 publicKeyMultibase begins with "z6Mk" because the
+        // varint multicodec prefix is [0xED, 0x01] for ed25519-pub (0xED).
+        var rawKey = DeterministicKey(32);
+        var multibase = Multikey.Encode(Multicodec.Ed25519Pub, rawKey);
+
+        Assert.StartsWith("z6Mk", multibase, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Decode_KnownEd25519Vector_RoundTripsTo32ByteKey()
+    {
+        // Self-contained known vector: deterministic 32-byte raw key encoded with the new API,
+        // decoded with TryDecode, then asserted byte-equal. Catches any prefix-handling regression.
+        var rawKey = new byte[32];
+        for (var i = 0; i < rawKey.Length; i++)
+        {
+            rawKey[i] = (byte)i;
+        }
+
+        var multibase = Multikey.Encode(Multicodec.Ed25519Pub, rawKey);
+
+        Assert.True(Multikey.TryDecode(multibase, out var codec, out var decoded));
+        Assert.Equal(Multicodec.Ed25519Pub, codec);
+        Assert.NotNull(decoded);
+        Assert.Equal(32, decoded!.Length);
+        Assert.Equal(rawKey, decoded);
+    }
+
+    private static byte[] DeterministicKey(int length)
+    {
+        var bytes = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            bytes[i] = (byte)(i + 1);
+        }
+
+        return bytes;
+    }
+}

--- a/NetCid.Tests/MultikeyTests.cs
+++ b/NetCid.Tests/MultikeyTests.cs
@@ -53,8 +53,10 @@ public sealed class MultikeyTests
     [Fact]
     public void Encode_Throws_OnContentCodecDagPb()
     {
-        Assert.Throws<ArgumentException>(
+        var ex = Assert.Throws<ArgumentException>(
             () => Multikey.Encode(Multicodec.DagPb, new byte[32]));
+
+        Assert.Equal("keyCodec", ex.ParamName);
     }
 
     [Theory]
@@ -136,9 +138,9 @@ public sealed class MultikeyTests
     }
 
     [Fact]
-    public void Decode_KnownEd25519Vector_RoundTripsTo32ByteKey()
+    public void Decode_DeterministicEd25519Key_RoundTrips()
     {
-        // Self-contained known vector: deterministic 32-byte raw key encoded with the new API,
+        // Deterministic 32-byte raw key (bytes 0..31) encoded with the new API,
         // decoded with TryDecode, then asserted byte-equal. Catches any prefix-handling regression.
         var rawKey = new byte[32];
         for (var i = 0; i < rawKey.Length; i++)

--- a/NetCid/Multikey.cs
+++ b/NetCid/Multikey.cs
@@ -1,0 +1,131 @@
+namespace NetCid;
+
+/// <summary>
+/// Helpers for the W3C Controlled Identifiers 1.0 Multikey verification method
+/// and the equivalent <c>did:key</c> identifier encoding:
+/// <c>publicKeyMultibase = base58btc( varint(keyCodec) || rawPublicKey )</c>.
+/// </summary>
+public static class Multikey
+{
+    /// <summary>
+    /// Encode a raw public key of the given key-type multicodec as a Multikey
+    /// <c>publicKeyMultibase</c> string (base58btc, leading <c>'z'</c>).
+    /// </summary>
+    /// <param name="keyCodec">One of the eight supported key-type multicodecs.</param>
+    /// <param name="rawKey">Raw public-key bytes. Edwards/Montgomery curves use their raw
+    /// 32-byte encoding; NIST P-curves and secp256k1 use compressed-point form; BLS keys
+    /// use their canonical 48-/96-byte serialization.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="keyCodec"/> is not a supported key-type multicodec, or
+    /// <paramref name="rawKey"/> has the wrong length for that codec.
+    /// </exception>
+    public static string Encode(ulong keyCodec, ReadOnlySpan<byte> rawKey)
+    {
+        EnsureKnownKeyType(keyCodec, nameof(keyCodec));
+        EnsureKeyLength(keyCodec, rawKey.Length, nameof(rawKey));
+        var prefixed = Multicodec.Prefix(keyCodec, rawKey);
+        return Multibase.Encode(prefixed, MultibaseEncoding.Base58Btc, includePrefix: true);
+    }
+
+    /// <summary>
+    /// Decode a Multikey <c>publicKeyMultibase</c> string into its key-type multicodec
+    /// and raw public key. Validates the multibase prefix, multicodec category, and
+    /// per-codec key length.
+    /// </summary>
+    /// <exception cref="CidFormatException">The input is not a valid Multikey value.</exception>
+    public static (ulong KeyCodec, byte[] RawKey) Decode(string publicKeyMultibase)
+    {
+        if (!TryDecode(publicKeyMultibase, out var codec, out var raw))
+        {
+            throw new CidFormatException("Invalid publicKeyMultibase value.");
+        }
+
+        return (codec, raw!);
+    }
+
+    /// <summary>
+    /// Try to decode a Multikey <c>publicKeyMultibase</c> string. Returns <see langword="false"/>
+    /// for any non-base58btc multibase, any non-key-type multicodec, or any payload whose raw
+    /// length does not match the codec.
+    /// </summary>
+    public static bool TryDecode(string publicKeyMultibase, out ulong keyCodec, out byte[]? rawKey)
+    {
+        keyCodec = 0;
+        rawKey = null;
+
+        if (!Multibase.TryDecode(publicKeyMultibase, out var bytes, out var encoding))
+        {
+            return false;
+        }
+
+        if (encoding != MultibaseEncoding.Base58Btc)
+        {
+            return false;
+        }
+
+        if (!Multicodec.TryDecode(bytes, out var codec, out var raw))
+        {
+            return false;
+        }
+
+        if (!IsKnownKeyType(codec))
+        {
+            return false;
+        }
+
+        if (raw is null || !KeyLengthMatches(codec, raw.Length))
+        {
+            return false;
+        }
+
+        keyCodec = codec;
+        rawKey = raw;
+        return true;
+    }
+
+    /// <summary>Expected raw-key byte length for a supported Multikey codec, or -1 if unknown.</summary>
+    private static int ExpectedLength(ulong codec) => codec switch
+    {
+        Multicodec.Ed25519Pub => 32,
+        Multicodec.X25519Pub => 32,
+        Multicodec.Secp256k1Pub => 33,
+        Multicodec.P256Pub => 33,
+        Multicodec.P384Pub => 49,
+        Multicodec.P521Pub => 67,
+        Multicodec.Bls12381G1Pub => 48,
+        Multicodec.Bls12381G2Pub => 96,
+        _ => -1,
+    };
+
+    private static bool IsKnownKeyType(ulong codec) => ExpectedLength(codec) >= 0;
+
+    private static bool KeyLengthMatches(ulong codec, int length) => ExpectedLength(codec) == length;
+
+    private static void EnsureKnownKeyType(ulong codec, string paramName)
+    {
+        if (IsKnownKeyType(codec))
+        {
+            return;
+        }
+
+        var name = Multicodec.TryGetName(codec, out var n) ? $"{n} (0x{codec:X})" : $"0x{codec:X}";
+        throw new ArgumentException(
+            $"Multicodec {name} is not a supported Multikey key type. " +
+            "Supported codecs: ed25519-pub, x25519-pub, secp256k1-pub, p256-pub, p384-pub, p521-pub, bls12_381-g1-pub, bls12_381-g2-pub.",
+            paramName);
+    }
+
+    private static void EnsureKeyLength(ulong codec, int actual, string paramName)
+    {
+        var expected = ExpectedLength(codec);
+        if (expected == actual)
+        {
+            return;
+        }
+
+        Multicodec.TryGetName(codec, out var name);
+        throw new ArgumentException(
+            $"Raw key length {actual} does not match the expected {expected} bytes for {name ?? $"0x{codec:X}"}.",
+            paramName);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@
 - Multicodec constants for common CID codecs (`raw`, `dag-pb`, `dag-cbor`, etc.)
 - Multicodec key-type constants (`ed25519-pub`, `p256-pub`, `secp256k1-pub`, etc.)
 - Multicodec prefix/decode API for varint-tagged byte buffers
+- `Multikey` — encode/decode W3C Controlled Identifiers `publicKeyMultibase` (base58btc(varint(keyCodec) ‖ rawKey)) with per-codec key-length validation; one call replaces the manual `Multicodec.Prefix` + `Multibase.Encode` dance for `did:key` construction
 - `JcsCanonicalizer` — RFC 8785 JSON Canonicalization Scheme for stable content-addressing of JSON values, and `Cid.FromCanonicalJson` convenience
+
+For the full list of specifications this library implements, the version/reference each targets, the governing body, and that specification's standardization status, see [`net-cid-implemented-specs.md`](net-cid-implemented-specs.md).
 
 ## Install
 

--- a/examples/did-key-interface/Program.cs
+++ b/examples/did-key-interface/Program.cs
@@ -8,40 +8,36 @@ Random.Shared.NextBytes(rawPublicKey);
 Console.WriteLine("=== did:key construction ===\n");
 Console.WriteLine($"  Raw Ed25519 public key: {Convert.ToHexString(rawPublicKey).ToLowerInvariant()}");
 
-// --- Step 1: Prefix the raw key with the multicodec tag ---
+// --- Step 1: Encode as Multikey publicKeyMultibase in one call ---
 
-var prefixed = Multicodec.Prefix(Multicodec.Ed25519Pub, rawPublicKey);
-Console.WriteLine($"  Multicodec-prefixed:    {Convert.ToHexString(prefixed).ToLowerInvariant()}");
-
-// --- Step 2: Encode with base58btc for did:key format ---
-
-var multibaseEncoded = Multibase.Encode(prefixed, MultibaseEncoding.Base58Btc, includePrefix: true);
+var multibaseEncoded = Multikey.Encode(Multicodec.Ed25519Pub, rawPublicKey);
 var didKey = $"did:key:{multibaseEncoded}";
+Console.WriteLine($"  publicKeyMultibase:     {multibaseEncoded}");
 Console.WriteLine($"  did:key identifier:     {didKey}");
 
-// --- Step 3: Decode it back ---
+// --- Step 2: Decode it back ---
 
 Console.WriteLine("\n=== Decoding did:key ===\n");
 
 var multibasePart = didKey["did:key:".Length..];
-var decodedPrefixed = Multibase.Decode(multibasePart, out var encoding);
-Console.WriteLine($"  Multibase encoding:     {encoding}");
-
-var (codec, recoveredKey) = Multicodec.Decode(decodedPrefixed);
+var (codec, recoveredKey) = Multikey.Decode(multibasePart);
 Multicodec.TryGetName(codec, out var codecName);
 Console.WriteLine($"  Key type codec:         0x{codec:X} ({codecName})");
 Console.WriteLine($"  Recovered public key:   {Convert.ToHexString(recoveredKey).ToLowerInvariant()}");
 Console.WriteLine($"  Keys match:             {rawPublicKey.AsSpan().SequenceEqual(recoveredKey)}");
 
-// --- Step 4: base64url encoding for Data Integrity proofs ---
+// --- Step 3: base64url encoding for Data Integrity proofs ---
+// (Multikey itself is base58btc only; this shows the underlying primitives for non-Multikey use.)
 
 Console.WriteLine("\n=== Alternative encoding (base64url for Data Integrity) ===\n");
 
+var prefixed = Multicodec.Prefix(Multicodec.Ed25519Pub, rawPublicKey);
 var base64UrlEncoded = Multibase.Encode(prefixed, MultibaseEncoding.Base64Url, includePrefix: true);
 Console.WriteLine($"  base64url (multibase):  {base64UrlEncoded}");
 
-// Round-trip verification
+// Round-trip verification (cannot use Multikey.Decode — it rejects non-base58btc)
 var decodedFromBase64Url = Multibase.Decode(base64UrlEncoded, out var encoding2);
 var (codec2, recoveredKey2) = Multicodec.Decode(decodedFromBase64Url);
 Console.WriteLine($"  Detected encoding:      {encoding2}");
 Console.WriteLine($"  Round-trip matches:     {rawPublicKey.AsSpan().SequenceEqual(recoveredKey2)}");
+Console.WriteLine($"  Multikey rejects it:    {!Multikey.TryDecode(base64UrlEncoded, out _, out _)}");

--- a/net-cid-implemented-specs.md
+++ b/net-cid-implemented-specs.md
@@ -15,7 +15,7 @@
 
 - **Multibase, Multicodec, and Multihash are implemented as CID-focused subsets** of their full registries, by design. `NetCid` covers the encodings, codecs, and hash functions needed for content addressing and decentralized-identity key encoding, not every entry in the upstream tables.
 - **Multihash hashing helpers** are provided for SHA-256 and SHA-512. The multihash wire format itself round-trips any function code; only these two have built-in digest computation.
-- **JCS number support is currently limited to integers** in `[long.MinValue, ulong.MaxValue]`; fractional and exponential numbers throw `JcsFormatException`. Full RFC 8785 (ECMAScript) number serialization is planned for a future release.
+- **JCS number support is RFC 8785-complete** as of 1.6.0: integers, fractional values, scientific notation, and integers beyond ±2<sup>53</sup> all canonicalize via the ECMA-262 §6.1.6.1.20 (`Number.prototype.toString`) algorithm required by RFC 8785 §3.2.2.3. The only numeric values that still throw `JcsFormatException` are `NaN` and `±∞`, which the spec forbids.
 - **CID versions 2 and 3 are rejected as reserved**, per the CID specification.
 - The **key-type multicodecs** identify public keys whose formats are defined elsewhere (Ed25519/X25519: RFC 8032 / RFC 7748; NIST P-curves: FIPS 186; secp256k1: SEC 2; BLS12-381: IRTF CFRG work). `NetCid` encodes their multicodec tags; it does not implement those cryptographic specifications.
 
@@ -28,4 +28,4 @@
 - Unsigned Varint — https://github.com/multiformats/unsigned-varint
 - JCS — https://www.rfc-editor.org/rfc/rfc8785
 
-_Last reviewed: 2026-06-06._
+_Last reviewed: 2026-06-07._


### PR DESCRIPTION
Closes #14.

## Summary

- Adds a first-class `NetCid.Multikey` static class implementing the W3C Controlled Identifiers 1.0 *Multikey* verification method: `publicKeyMultibase = base58btc( varint(keyCodec) ‖ rawPublicKey )`. Same construction underlies `did:key`.
- Strict by default — rejects non-base58btc multibases, content-type codecs, and any payload whose raw-key length does not match the codec.
- Lets `net-did` (and any future SSI consumer) depend on one canonical, tested implementation and delete the manual `Multicodec.Prefix` + `Multibase.Encode` dance.
- Bundled into the existing 1.6.0 release line — purely additive, no version bump.

## Why this matters

Before this PR every consumer hand-assembled the two-step encode in user code — visible at `examples/did-key-interface/Program.cs:11-20` before, and duplicated in `net-did`. After this PR the workflow collapses to a single call:

```csharp
var publicKeyMultibase = Multikey.Encode(Multicodec.Ed25519Pub, rawKey);
var (codec, raw) = Multikey.Decode(publicKeyMultibase);
```

## What's in here

- `NetCid/Multikey.cs` — `Encode` / `Decode` / `TryDecode` + per-codec key-length validation for the eight supported public-key codecs (`ed25519-pub`, `x25519-pub`, `secp256k1-pub`, `p256-pub`, `p384-pub`, `p521-pub`, `bls12_381-g1-pub`, `bls12_381-g2-pub`). No new dependencies — composes the existing `Multicodec` and `Multibase` primitives.
- `NetCid.Tests/MultikeyTests.cs` — 34 new tests: round-trip across all 8 codecs, wrong-length rejection, non-base58btc-multibase rejection (base32 + base64url), content-codec rejection (`raw`, `dag-pb`), null/empty input, `CidFormatException` on bad input, the `z6Mk` Ed25519 multikey-prefix signature, and a known-vector round-trip.
- `examples/did-key-interface/Program.cs` — switched to `Multikey.Encode` / `Multikey.Decode`; the base64url section now also demonstrates that `Multikey.TryDecode` correctly rejects a non-base58btc multibase.
- Docs: `README.md` Features bullet + a new pointer to `net-cid-implemented-specs.md`; `ARCHITECTURE.md` class-table row and a note under the did:key flow; `CHANGELOG.md` 1.6.0 `Added` entry referencing #14.
- Bonus fix in `net-cid-implemented-specs.md`: refreshed the stale "JCS number support is currently limited to integers" bullet — full RFC 8785 number support landed in 1.6.0 (#13), so only `NaN`/`±∞` still throw `JcsFormatException`. Bumped `Last reviewed` to 2026-06-07.

## Out of scope (deferred)

- Companion `net-did` issue to depend on `NetCid.Multikey` and delete its local helper — will open after merge.
- Uncompressed-EC-point lengths — explicit non-goal per the issue.
- Secret-key Multikey variant — public keys only for v1, matching the issue.

## Test plan

- [x] `dotnet build NetCid.sln -c Release --tl:off` → 0 warnings, 0 errors
- [x] `dotnet test NetCid.Tests/NetCid.Tests.csproj -c Release --no-build --tl:off` → 184 passed, 1 skipped (pre-existing conformance gate; was 150 before)
- [x] `dotnet test NetCid.IntegrationTests/NetCid.IntegrationTests.csproj -c Release --no-build --tl:off` → 6/6
- [x] `dotnet run --project examples/did-key-interface/DidKeyInterfaceExample.csproj -c Release --no-build --tl:off` → emits `did:key:z6Mk…`, "Keys match: True", and "Multikey rejects it: True" for the base64url variant
- [x] Spot-checked that an Ed25519 raw key produces the canonical `z6Mk…` Multikey prefix (varint `0xED 0x01` + 32 bytes always base58btc-encodes to that leading 4 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)