### PR TITLE
Reject non-canonical base32 trailing symbol (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `Multibase` now rejects base32 payloads that carry an incomplete trailing symbol (payload length ≡ {1,3,6} mod 8). A canonical RFC 4648 no-padding base32 length is always ≡ {0,2,4,5,7} mod 8; the previous validator checked only that the unused trailing *bits* were zero, so appending a single zero-valued symbol (`a`/`A`) produced a distinct string that decoded to the same bytes — two distinct strings mapping to one CID (`Cid.Parse`), a CID string-malleability vector. Decoding such a non-canonical payload now throws `CidFormatException`; canonical CIDs are unaffected ([#42](https://github.com/moisesja/net-cid/issues/42)).
 - Made the NuGet dependency vulnerability scan fail the build when `dotnet list --vulnerable --include-transitive` reports an advisory of any severity, in both the `ci` and `security` workflows; previously the scan only printed its findings and always exited `0`, so a newly vulnerable transitive dependency could merge cleanly ([#25](https://github.com/moisesja/net-cid/issues/25)).
 - Added a release-workflow guard that verifies the pushed git tag matches the package `<Version>` in `NetCid.csproj` before packing and publishing, so a tag/version mismatch fails fast instead of mispublishing or being silently swallowed by `--skip-duplicate` ([#26](https://github.com/moisesja/net-cid/issues/26)).
 

--- a/NetCid.Tests/MultibaseTests.cs
+++ b/NetCid.Tests/MultibaseTests.cs
@@ -215,4 +215,47 @@ public sealed class MultibaseTests
         Assert.Equal(MultibaseEncoding.Base64Url, encoding);
         Assert.Equal(new[] { (byte)expected }, decoded);
     }
+
+    [Fact]
+    public void Decode_RejectsBase32IncompleteTrailingSymbolCollision()
+    {
+        // A canonical base32 CID has a payload length ≡ {0,2,4,5,7} mod 8. Appending one zero-valued
+        // symbol ('a') makes it ≡ 3 mod 8 — a whole incomplete trailing symbol that SimpleBase would
+        // silently drop, decoding to the SAME bytes as the canonical form. That is CID string
+        // malleability: two distinct strings → one CID. The canonical form decodes; the mutated form
+        // must throw. See issue #42.
+        var canonical = Multibase.Decode(KnownCidBase32, out var encoding);
+        Assert.Equal(MultibaseEncoding.Base32Lower, encoding);
+        Assert.Equal(KnownCidBytesHex, Convert.ToHexString(canonical).ToLowerInvariant());
+
+        Assert.Throws<CidFormatException>(() => Multibase.Decode(KnownCidBase32 + "a"));
+    }
+
+    [Theory]
+    [InlineData("ba")]        // payload len 1  (≡ 1 mod 8) — single dangling zero symbol
+    [InlineData("baaa")]      // payload len 3  (≡ 3 mod 8)
+    [InlineData("baaaaaa")]   // payload len 6  (≡ 6 mod 8)
+    public void Decode_ThrowsOnBase32IncompleteTrailingSymbol(string nonCanonical)
+    {
+        // Payload lengths ≡ {1,3,6} mod 8 carry an incomplete trailing base32 symbol (≥5 unused bits)
+        // that cannot occur in a canonical no-padding encoding. Even when those bits are zero (so the
+        // non-zero-trailing-bits check passes), the dangling symbol must be rejected to prevent
+        // malleability. See issue #42.
+        Assert.Throws<CidFormatException>(() => Multibase.Decode(nonCanonical));
+    }
+
+    [Theory]
+    [InlineData("baa", new byte[] { 0x00 })]                          // payload len 2 (≡ 2 mod 8)
+    [InlineData("baaaa", new byte[] { 0x00, 0x00 })]                  // payload len 4 (≡ 4 mod 8)
+    [InlineData("baaaaa", new byte[] { 0x00, 0x00, 0x00 })]           // payload len 5 (≡ 5 mod 8)
+    [InlineData("baaaaaaa", new byte[] { 0x00, 0x00, 0x00, 0x00 })]   // payload len 7 (≡ 7 mod 8)
+    public void Decode_AcceptsCanonicalBase32PartialGroupLengths(string canonical, byte[] expected)
+    {
+        // The legitimate partial-group lengths ({2,4,5,7} mod 8) leave <5 unused (zero) bits and must
+        // still decode — the incomplete-trailing-symbol guard added for #42 must not over-reject them.
+        var decoded = Multibase.Decode(canonical, out var encoding);
+
+        Assert.Equal(MultibaseEncoding.Base32Lower, encoding);
+        Assert.Equal(expected, decoded);
+    }
 }

--- a/NetCid/Multibase.cs
+++ b/NetCid/Multibase.cs
@@ -299,6 +299,18 @@ public static class Multibase
             }
         }
 
+        // A canonical RFC 4648 (no-padding) base32 symbol count is always ≡ {0,2,4,5,7} mod 8, which
+        // leaves fewer than 5 unused trailing bits. Counts ≡ {1,3,6} mod 8 carry a whole *incomplete*
+        // trailing symbol (5/7/6 unused bits) that cannot occur canonically. When that symbol is the
+        // zero-valued 'a'/'A', the non-zero-bits check below passes and SimpleBase silently drops the
+        // incomplete group, so the non-canonical string decodes to the same bytes as the canonical one
+        // — CID string malleability (#42). Reject the dangling symbol; the check below still rejects
+        // non-zero padding bits for the legitimate {2,4,5,7} partial-group cases.
+        if (bitsInBuffer >= 5)
+        {
+            throw new CidFormatException("Invalid base32 payload length: incomplete trailing symbol.");
+        }
+
         if (bitsInBuffer > 0 && (buffer & ((1 << bitsInBuffer) - 1)) != 0)
         {
             throw new CidFormatException("Invalid non-zero trailing bits in base32 payload.");

--- a/tasks/todo-20260609-security-release-scan.md
+++ b/tasks/todo-20260609-security-release-scan.md
@@ -1,0 +1,102 @@
+# Release Security Scan & Remediation Loop — 2026-06-09
+
+## Context
+
+User request (pre-authorized end-to-end loop): full security/vulnerability scan of
+`main` in preparation for a release → file a GitHub issue per finding → then for each
+issue: branch → fix → PR → wait for the user's PR-review routine → address review
+comments → merge → delete branch → repeat until all issues cleared.
+
+Base: `origin/main` @ 271da43 (post-#41). Prior audit (SECURITY_AUDIT.md, 2026-06-08)
+reports S1–S4 resolved in 1.6.0, no open findings — this round hunts what it missed.
+
+## Exclusions (do NOT re-file)
+
+- #24 GitHub Actions SHA-pinning — **declined by maintainer preference** (lessons 2026-06-09); Dependabot handles action bumps.
+- `dependency-review` CI job failure — pre-existing **repo settings** gap (Dependency graph disabled), not a code issue.
+- S3 residual gap (`JsonValue` wrapping raw CLR object) — documented usage constraint by maintainer decision.
+- S1–S4 themselves — resolved & shipped.
+
+## Phase A — Scan (parallel adversarial subagents + tooling)
+
+- [ ] A1 dependency scan: `dotnet list package --vulnerable --include-transitive` + `--deprecated` (locked-mode restore)
+- [ ] A2 CID/Multihash/Varint/Multicodec parsing audit (adversarial, empirical probes)
+- [ ] A3 Multibase + SimpleBase wrapper audit (canonicality/malleability/DoS)
+- [ ] A4 JCS canonicalizer + EcmaScriptNumber fresh adversarial pass (post-S1–S4 gaps)
+- [ ] A5 Multikey / did:key codec audit
+- [ ] A6 API-surface/packaging/docs audit (thread safety, info leakage, csproj/release metadata)
+- [ ] A7 CI + release workflow audit (injection, permissions, release integrity; excl. SHA-pinning)
+
+## Phase B — Adversarial verification of findings — DONE
+
+Dependency posture: **clean** (0 vulnerable / 0 deprecated across 10 projects, locked-mode).
+6 parallel adversarial scan agents + my own end-to-end probes (`/tmp/netcid-verify`).
+
+### VERIFIED FINDINGS (reproduced end-to-end through public API)
+
+| # | Sev | Title | Path | Verified |
+|---|-----|-------|------|----------|
+| F1 | HIGH | base32 zero-symbol length malleability → 2 strings → 1 CID | `Multibase.ValidateBase32Payload` (`Multibase.cs:267`); reached via `Cid.Parse` | `bafkrei…yeq` & `bafkrei…yeqa` → identical CID `0155…9824`. Only dangling-symbol append (payload len mod 8 ∈ {1,3,6}) slips; mod8∈{4,5,0} correctly rejected. |
+| F2 | MEDIUM | base36 Unicode case-fold malleability (Kelvin U+212A→k, long-s U+017F→S) | `Multibase.DecodeBase36` folds case BEFORE alphabet validation (`Multibase.cs:179`) | distinct base36 string → same CID via `Cid.Parse`. Found by 2 agents independently. |
+| F3 | MEDIUM | tr-TR/az locale: `Try*` throws `IndexOutOfRangeException`, exception-normalization bypass | SimpleBase case-insensitive alphabet built with culture-sensitive `char.ToUpper`; wrapper catches don't cover it (`Multibase.cs:158,179,82`) | `Cid.TryParse`/`Multibase.TryDecode` throw uncaught under tr-TR at first base32 touch. Environmental (locale-gated), breaks documented Try*/normalization control. |
+| F4 | MEDIUM | Multikey accepts invalid SEC1 EC point prefix (0x04/any) on encode+decode | `Multikey` validates length only, not `rawKey[0]∈{0x02,0x03}` for secp256k1/p256/p384/p521 (`Multikey.cs:87-102`) | `Encode(P256Pub, 0x04‖32×00)` mints a did:key; `TryDecode` accepts it. Spec mandates compressed form. |
+| F5 | MEDIUM | release.yml `workflow_dispatch` from a branch bypasses tag-vs-version guard | `release.yml:40-43` `exit 0` on non-tag ref, then publishes | docs-confirmed `GITHUB_REF_TYPE=branch` on dispatch → guard skipped → `nuget push`. Requires repo write (not external). |
+| F6 | LOW | JCS NaN/∞ in `JsonValue`-wrapped CLR object throws `ArgumentException` not `JcsFormatException` | `JcsCanonicalizer.cs:226-235` catch only `JsonException` | fails closed (no bad bytes), wrong exception type only. Narrow reachability (programmatic node). |
+| F7 | LOW | jcs-conformance.yml empty SHA-256 pin → warn-only download integrity | `jcs-conformance.yml:28,62-72` `CONFORMANCE_EXPECTED_SHA256: ''` | test-only blast radius; not in published-artifact path. |
+
+### REFUTED / NOT FILED (audit trail)
+- Vuln-scan gate (#25) — re-verified **sound** (fail-closed; URL token + locale pin robust).
+- tag-guard tag-triggered path (#26) — **sound**; only the dispatch path (F5) is weak.
+- JCS number serialization, key-ordering (UTF-16 code units), dup-key (S2), surrogate (S3), depth/output caps (S1), escaping — heavy fuzz, **0 divergences**; no new bypass.
+- CID core: varint canonicality/9-byte cap, MultihashDigest overflow/alloc guards, reserved v2/v3, CIDv0 constraints — held.
+- Concurrency / array-aliasing / info-leak / API exception-type robustness — verified **clean** by demonstration.
+- Base58 quadratic time — bounded by 4096 input cap; documented residual.
+- S3 `JsonValue`-raw-CLR surrogate residual — documented maintainer decision; not re-filed.
+
+### Release-hygiene notes (NOT security; surface to user, file only if wanted)
+- H1 `<Version>` still 1.6.0 with shipped `[Unreleased]` items — normal release-prep step (fails safe via tag guard).
+- H2 assembly not strong-named — policy decision; document.
+- H3 no PublicApiAnalyzers/PackageValidation breaking-change guard — enhancement.
+- H4 `release.yml --skip-duplicate` softens double-publish detection — minor; fold into F5 fix.
+
+## Phase C — File GitHub issues — DONE
+
+Filed 2026-06-09 against moisesja/net-cid:
+
+| Finding | Issue | Title | Sev |
+|---------|-------|-------|-----|
+| F1 | #42 | S5 base32 trailing-symbol malleability | HIGH |
+| F2 | #43 | S6 base36 case-fold malleability | MED |
+| F3 | #44 | S7 tr-TR Try* IndexOutOfRangeException | MED |
+| F4 | #45 | S8 Multikey EC SEC1 prefix | MED |
+| F5 | #46 | S9 release.yml dispatch bypass (+H4 --skip-duplicate) | MED |
+| F6 | #47 | S10 JCS NaN ArgumentException | LOW |
+| F7 | #48 | S11 jcs-conformance SHA-256 pin | LOW |
+| H3 | #49 | D5 PackageValidation API-break guard | LOW |
+| H2 | #50 | D6 strong-naming decision (document) | LOW |
+
+Fix order: #42 → #43 → #44 → #45 → #46 → #47 → #48 → #49 → #50
+(HIGH first; F1/F2/F3 share Multibase.cs so done consecutively with re-sync between).
+
+## Phase D — Per-issue fix loop (repeat for each)
+
+- [ ] `git fetch origin && reset onto origin/main` (re-sync RIGHT BEFORE first edit)
+- [ ] branch `feature/issue-N-<slug>`
+- [ ] empirically confirm failure mechanism (issue's proposed fix may be wrong — lessons 2026-06-07/08)
+- [ ] implement fix + tests (boundary AND far-over tests where DoS; pin default-path behavior)
+- [ ] full build + test suite green
+- [ ] adversarial review round(s) — ≥2 rounds for security fixes
+- [ ] update CHANGELOG/docs/examples
+- [ ] push branch, open PR (`Closes #N`), wait for user's PR-review routine
+- [ ] address review comments, push
+- [ ] CI green → merge (merge commit, per repo history) → delete branch
+
+## Phase E — Final verification
+
+- [ ] All issues closed, full suite green on main, vuln scan clean
+- [ ] SECURITY_AUDIT.md updated with this round's findings/status
+- [ ] Review section appended below
+
+## Review
+
+(to be completed)


### PR DESCRIPTION
Closes #42.

## Problem
`Multibase.ValidateBase32Payload` only rejected non-zero unused trailing **bits**, not a structurally-invalid **length**. A canonical RFC 4648 no-padding base32 symbol count is always ≡ {0,2,4,5,7} mod 8; counts ≡ {1,3,6} mod 8 carry a whole incomplete trailing symbol. When that symbol was the zero-valued `a`/`A`, validation passed and SimpleBase silently dropped it — so a non-canonical string decoded to the **same bytes** as the canonical one.

Verified end-to-end: `bafkrei…yeq` and `bafkrei…yeqa` both parsed to the identical CID `0155…9824` via `Cid.Parse` (two distinct strings → one CID). This is a CID string-malleability vector for a content-addressing / signature-input library.

## Fix
After the symbol loop, reject `bitsInBuffer >= 5` (an incomplete trailing symbol) before the existing non-zero-bits check. Canonical lengths leave <5 unused bits, so valid CIDs are never affected.

## Verification
- New regression tests: collision pinned to rejected, `{1,3,6}`-mod-8 (zero and non-zero) rejected, `{2,4,5,7}` canonical lengths still decode.
- Full suite green (238 passed, 1 skipped) + 6 integration tests.
- Probe re-run: `Cid.TryParse(canonical + "a")` now returns `false` (was `true`).
- **Two adversarial review rounds**: (1) no remaining base32 malleability bypass; (2) no over-rejection — proven analytically over N=0..100,000 byte lengths that canonical lengths never land in {1,3,6} mod 8, plus 4M round-trips clean.

The case-insensitive (ASCII mixed-case / Unicode case-fold) malleability axis is intentional/separate and tracked as #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)