### PR TITLE
Add public-API breaking-change guard via package validation (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SDK-native package validation (`EnablePackageValidation` + `PackageValidationBaselineVersion`) in `NetCid.csproj`: every `dotnet pack` — including the CI `build-test-pack` job on each PR — now compares the public API surface against the last **published** nuget.org version and fails on an undocumented breaking change. The baseline is `1.5.0` (note: `1.6.0` exists in the csproj/CHANGELOG but was never published to nuget.org). The single intentional 1.6.0-era break — `Cid.FromCanonicalJson` gaining the optional `maxOutputBytes` parameter ([#16](https://github.com/moisesja/net-cid/issues/16)), already documented as potentially breaking — is recorded in the new `NetCid/CompatibilitySuppressions.xml`. Release checklist: after shipping a version, bump the baseline to it and clear the suppressions ([#49](https://github.com/moisesja/net-cid/issues/49)).
+
 ### Fixed
 
 - `JcsCanonicalizer` now throws the documented `JcsFormatException` (instead of leaking System.Text.Json's `ArgumentException`) when `NaN`/`±Infinity` hides inside a `JsonValue` wrapping a raw CLR object (e.g. a `Dictionary`/POCO), across all `Canonicalize` overloads and `Cid.FromCanonicalJson`. The failure was already closed (no canonical bytes were produced) — only the exception type violated the documented contract. Parsed JSON text is unaffected (System.Text.Json rejects `NaN`/`Infinity` tokens at parse time); only programmatic node construction could reach this path ([#47](https://github.com/moisesja/net-cid/issues/47)).

--- a/NetCid/CompatibilitySuppressions.xml
+++ b/NetCid/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:NetCid.Cid.FromCanonicalJson(System.Text.Json.Nodes.JsonNode,System.UInt64,System.UInt64)</Target>
+    <Left>lib/net10.0/NetCid.dll</Left>
+    <Right>lib/net10.0/NetCid.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/NetCid/NetCid.csproj
+++ b/NetCid/NetCid.csproj
@@ -21,6 +21,13 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <NoWarn>$(NoWarn);CS1591;CA1707;CA1859</NoWarn>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <!-- Public-API breaking-change guard (#49): dotnet pack compares this package's API
+         surface against the LAST PUBLISHED nuget.org version and fails on an undocumented
+         break. Intentional breaks are recorded in CompatibilitySuppressions.xml. On each
+         release: bump the baseline to the version just shipped and clear the suppressions.
+         Note: APIs added after the baseline version are not protected until the bump. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>1.5.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #49.

## What

SDK-native package validation in `NetCid.csproj`:

```xml
<EnablePackageValidation>true</EnablePackageValidation>
<PackageValidationBaselineVersion>1.5.0</PackageValidationBaselineVersion>
```

Every `dotnet pack` — including CI's `build-test-pack` job on each PR — now compares the public API surface against the last published nuget.org version and fails on an undocumented break.

## Baseline is 1.5.0, not 1.6.0

The issue suggested `1.6.0`, but **1.6.0 was never published** — nuget.org's flat-container index for `NetCid` ends at `1.5.0` (the csproj/CHANGELOG 1.6.0 is the unreleased in-flight version). A 1.6.0 baseline would fail restore. Per the issue's own criterion ("use the last published version"), the baseline is 1.5.0.

## CompatibilitySuppressions.xml (1 entry)

Validation immediately caught the one intentional 1.6.0-era break: `Cid.FromCanonicalJson(JsonNode?, ulong, ulong)` gained the optional `maxOutputBytes` parameter in #16 (binary-breaking; already documented as potentially breaking in the 1.6.0 CHANGELOG section). Recorded via `/p:ApiCompatGenerateSuppressionFile=true` — the file contains exactly that one suppression, demonstrating the guard works end-to-end.

## Verification

- Clean pack: green with baseline + suppression, in both full-pack and CI's exact `pack --no-build` shape; `packages.lock.json` untouched (baseline download bypasses the project restore graph, so `--locked-mode` CI restore is unaffected — the green `build-test-pack` check on this PR is the live proof).
- Mutation test: hiding the 1.5.0-era `Cid.ToByteArray()` fails pack with `CP0002` in both shapes; an API added after 1.5.0 (`Multikey.Encode`) is *not* caught — confirming the documented caveat that post-baseline additions are unprotected until the baseline bumps.
- Release checklist addition (csproj comment + CHANGELOG): after shipping a version, bump the baseline to it and clear the suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)