### PR TITLE
Add Multihash.EncodeBase58Btc and multihash/base58btc misuse guardrails (#62); version 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-07-12
+
+### Added
+
+- `Multihash.EncodeBase58Btc(hashFunctionCode, digest, includeMultibasePrefix)` — encodes a digest as a complete multihash (`varint(code) ‖ varint(digestLength) ‖ digest`) and renders it as base58btc text in one call. The multibase flag is deliberately required (no default) so bare-vs-`z`-multibase intent is explicit at every call site; no decode counterpart is provided because a bare base58btc string can itself begin with `z`, making an accept-either decoder ambiguous — compose `Multibase.DecodeBase58Btc`/`Multibase.Decode` with `Multihash.Decode` instead. Known-answer tests pin the `varint(code) ‖ varint(len) ‖ digest` wire shape and the bare (`Qm…`) vs multibase (`zQm…`) text forms ([#62](https://github.com/moisesja/net-cid/issues/62)).
+
+### Changed
+
+- Documentation-only hardening against multicodec/multihash misuse (no behavioral changes, no deprecations): XML docs on `Multibase.Encode`/`EncodeBase58Btc`/`DecodeBase58Btc` now call out the opposite `includePrefix` defaults and the bare-vs-multibase distinction; `Multicodec.Prefix` docs state its output is multicodec-tagged data, not a multihash (33 vs 34 bytes for SHA-256), and route digest callers to `Multihash` and key callers to `Multikey`; README gained a "Multihash vs Multicodec.Prefix, and bare vs multibase base58btc" section with the known-answer vector; the multihash and multibase examples demonstrate the distinction. Prompted by the did:webvh SCID misuse in [net-did#95](https://github.com/moisesja/net-did/issues/95) ([#62](https://github.com/moisesja/net-cid/issues/62)).
+
 ## [1.6.0] - 2026-06-10
 
 ### Added
@@ -108,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SHA-256 and SHA-512 multihash support
 - Core multicodec constants (raw, dag-pb, dag-cbor, etc.)
 
-[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/moisesja/net-cid/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/moisesja/net-cid/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/moisesja/net-cid/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/moisesja/net-cid/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/moisesja/net-cid/compare/v1.3.0...v1.4.0

--- a/NetCid.Tests/MultihashTests.cs
+++ b/NetCid.Tests/MultihashTests.cs
@@ -4,6 +4,89 @@ namespace NetCid.Tests;
 
 public sealed class MultihashTests
 {
+    // Known-answer vector from issue #62: SHA-256 of the UTF-8 input string.
+    private const string KnownInput = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    private const string KnownDigestHex = "79d8444cc417275da1aa2ed425afb37ba26353270bb09fa29ef8aa4318e13f41";
+    private const string KnownMultihashHex = "1220" + KnownDigestHex;
+    private const string KnownBareBase58 = "QmWYHJqmhJHuzQHMQ33piy86hYQwwNBKEFmCKzRMTi7UHN";
+
+    private static byte[] KnownDigest()
+        => SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(KnownInput));
+
+    [Fact]
+    public void Encode_MatchesKnownAnswerVector()
+    {
+        var digest = KnownDigest();
+        Assert.Equal(KnownDigestHex, Convert.ToHexString(digest).ToLowerInvariant());
+
+        var multihash = Multihash.Encode(MultihashCode.Sha2_256, digest);
+
+        Assert.Equal(KnownMultihashHex, Convert.ToHexString(multihash).ToLowerInvariant());
+        Assert.Equal(34, multihash.Length);
+        Assert.Equal(0x12, multihash[0]); // sha2-256 code
+        Assert.Equal(0x20, multihash[1]); // digest length 32
+        Assert.Equal(digest, multihash[2..]);
+    }
+
+    [Fact]
+    public void EncodeBase58Btc_BareMatchesKnownAnswer()
+    {
+        var bare = Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, KnownDigest(), includeMultibasePrefix: false);
+
+        Assert.Equal(KnownBareBase58, bare);
+        Assert.False(bare.StartsWith('z'));
+    }
+
+    [Fact]
+    public void EncodeBase58Btc_MultibasePrefixedMatchesKnownAnswer()
+    {
+        var prefixed = Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, KnownDigest(), includeMultibasePrefix: true);
+
+        Assert.Equal("z" + KnownBareBase58, prefixed);
+
+        var decodedBytes = Multibase.Decode(prefixed, out var encoding);
+        Assert.Equal(MultibaseEncoding.Base58Btc, encoding);
+
+        var (code, digest) = Multihash.Decode(decodedBytes);
+        Assert.Equal(MultihashCode.Sha2_256, code);
+        Assert.Equal(KnownDigest(), digest);
+    }
+
+    [Fact]
+    public void EncodeBase58Btc_MatchesManualComposition()
+    {
+        var digest = KnownDigest();
+        var multihash = Multihash.Encode(MultihashCode.Sha2_256, digest);
+
+        Assert.Equal(
+            Multibase.EncodeBase58Btc(multihash, includePrefix: false),
+            Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, digest, includeMultibasePrefix: false));
+        Assert.Equal(
+            Multibase.EncodeBase58Btc(multihash, includePrefix: true),
+            Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, digest, includeMultibasePrefix: true));
+    }
+
+    [Fact]
+    public void EncodeBase58Btc_DiffersFromMulticodecPrefixComposition()
+    {
+        // The exact downstream misuse from net-did#95: Multicodec.Prefix is not a multihash.
+        var digest = KnownDigest();
+        var tagged = Multicodec.Prefix(MultihashCode.Sha2_256, digest);
+
+        Assert.NotEqual(
+            Multibase.EncodeBase58Btc(tagged, includePrefix: false),
+            Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, digest, includeMultibasePrefix: false));
+    }
+
+    [Fact]
+    public void EncodeBase58Btc_ThrowsForOversizedCode()
+    {
+        var digest = KnownDigest();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Multihash.EncodeBase58Btc(Varint.MaxValue + 1, digest, includeMultibasePrefix: false));
+    }
+
     [Fact]
     public void Encode_ProducesCorrectMultihashFormat()
     {

--- a/NetCid/Multibase.cs
+++ b/NetCid/Multibase.cs
@@ -54,6 +54,18 @@ public static class Multibase
     private static readonly IReadOnlyDictionary<char, int> Base36UpperIndex = BuildAlphabetIndex(Base36UpperAlphabet);
     private static readonly IReadOnlyDictionary<char, int> Base58BtcIndex = BuildAlphabetIndex(Base58BtcAlphabet);
 
+    /// <summary>
+    /// Encode bytes in the given base encoding, optionally as a self-describing multibase string.
+    /// </summary>
+    /// <param name="bytes">The bytes to encode.</param>
+    /// <param name="encoding">The base encoding to use.</param>
+    /// <param name="includePrefix">
+    /// Defaults to <see langword="true"/>: the result carries the multibase prefix character
+    /// (e.g. <c>'z'</c> for base58btc). Pass <see langword="false"/> for the bare base encoding
+    /// when the governing protocol does not use multibase. Note that
+    /// <see cref="EncodeBase58Btc(ReadOnlySpan{byte}, bool)"/> has the opposite default —
+    /// prefer passing the argument explicitly at call sites.
+    /// </param>
     public static string Encode(ReadOnlySpan<byte> bytes, MultibaseEncoding encoding, bool includePrefix = true)
     {
         var payload = EncodeWithoutPrefix(bytes, encoding);
@@ -65,6 +77,22 @@ public static class Multibase
         return string.Concat(GetPrefix(encoding), payload);
     }
 
+    /// <summary>
+    /// Encode bytes as base58btc text.
+    /// </summary>
+    /// <param name="bytes">The bytes to encode.</param>
+    /// <param name="includePrefix">
+    /// Defaults to <see langword="false"/>: the result is bare base58btc with no leading
+    /// <c>'z'</c> (the form CIDv0 uses). Pass <see langword="true"/> for a self-describing
+    /// multibase string. This default is the opposite of
+    /// <see cref="Encode(ReadOnlySpan{byte}, MultibaseEncoding, bool)"/> — prefer passing the
+    /// argument explicitly at call sites. "base58btc" in a protocol spec does not automatically
+    /// mean "base58btc multibase".
+    /// </param>
+    /// <remarks>
+    /// To encode a digest as a complete multihash and then as base58btc in one call, use
+    /// <see cref="Multihash.EncodeBase58Btc"/>.
+    /// </remarks>
     public static string EncodeBase58Btc(ReadOnlySpan<byte> bytes, bool includePrefix = false)
         => Encode(bytes, MultibaseEncoding.Base58Btc, includePrefix);
 
@@ -121,9 +149,25 @@ public static class Multibase
         }
     }
 
+    /// <summary>
+    /// Decode a bare base58btc payload (no multibase prefix).
+    /// </summary>
+    /// <remarks>
+    /// The whole input is treated as base58btc digits: a leading <c>'z'</c> is decoded as a
+    /// digit, not stripped. For self-describing multibase strings use
+    /// <see cref="Decode(string)"/> or <see cref="TryDecode(string, out byte[], out MultibaseEncoding)"/>.
+    /// </remarks>
     public static byte[] DecodeBase58Btc(string payload)
         => DecodeBase58Btc(payload, DefaultMaxInputLength);
 
+    /// <summary>
+    /// Decode a bare base58btc payload (no multibase prefix) with a custom input-length limit.
+    /// </summary>
+    /// <remarks>
+    /// The whole input is treated as base58btc digits: a leading <c>'z'</c> is decoded as a
+    /// digit, not stripped. For self-describing multibase strings use
+    /// <see cref="Decode(string, out MultibaseEncoding, int)"/>.
+    /// </remarks>
     public static byte[] DecodeBase58Btc(string payload, int maxInputLength)
     {
         ValidateLimit(maxInputLength);

--- a/NetCid/Multicodec.cs
+++ b/NetCid/Multicodec.cs
@@ -87,8 +87,16 @@ public static class Multicodec
     public static bool TryGetCode(string name, out ulong code) => CodesByName.TryGetValue(name, out code);
 
     /// <summary>
-    /// Prefix raw bytes with the varint-encoded multicodec tag.
+    /// Prefix raw bytes with the varint-encoded multicodec tag: varint(codec) || rawBytes.
     /// </summary>
+    /// <remarks>
+    /// The output is multicodec-tagged data, not a multihash: there is no digest-length varint.
+    /// Do not use this to build a multihash from a digest — use <see cref="Multihash.Encode"/>
+    /// (or <see cref="Multihash.EncodeBase58Btc"/> for base58btc text); for a SHA-256 digest the
+    /// two differ (33 bytes tagged vs 34 bytes multihash) and are not interoperable.
+    /// Tagging then multibase-encoding IS the correct shape for public keys
+    /// (<c>did:key</c>, <c>publicKeyMultibase</c>) — use <see cref="Multikey"/> for those.
+    /// </remarks>
     public static byte[] Prefix(ulong codec, ReadOnlySpan<byte> rawBytes)
     {
         var prefixLength = Varint.GetEncodedLength(codec);

--- a/NetCid/Multihash.cs
+++ b/NetCid/Multihash.cs
@@ -10,8 +10,53 @@ public static class Multihash
     /// <summary>
     /// Encode a digest as a multihash: varint(hashFunctionCode) || varint(digestLength) || digest.
     /// </summary>
+    /// <remarks>
+    /// Not to be confused with <see cref="Multicodec.Prefix"/>, which produces
+    /// varint(codec) || data with no digest-length varint and is not a multihash.
+    /// For a SHA-256 digest a multihash is 34 bytes (<c>0x12 0x20 || digest</c>);
+    /// the multicodec-tagged form is 33 bytes.
+    /// </remarks>
     public static byte[] Encode(ulong hashFunctionCode, ReadOnlySpan<byte> digest)
         => new MultihashDigest(hashFunctionCode, digest).ToByteArray();
+
+    /// <summary>
+    /// Encode a digest as a complete multihash (varint(hashFunctionCode) || varint(digestLength) || digest)
+    /// and render it as base58btc text in one call.
+    /// </summary>
+    /// <param name="hashFunctionCode">The multihash function code, e.g. <see cref="MultihashCode.Sha2_256"/>.</param>
+    /// <param name="digest">The raw digest bytes.</param>
+    /// <param name="includeMultibasePrefix">
+    /// <see langword="true"/> to return a self-describing multibase string with a leading <c>'z'</c>
+    /// (use when the governing protocol says <c>multibase(...)</c>);
+    /// <see langword="false"/> to return bare base58btc with no <c>'z'</c>
+    /// (use when the protocol says <c>base58btc(...)</c> — for a SHA-256 multihash the result
+    /// commonly begins with <c>Qm</c>). The parameter has no default on purpose: whether the
+    /// prefix belongs depends on the protocol, so state the intent at every call site.
+    /// </param>
+    /// <returns>The base58btc text of the complete multihash.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="hashFunctionCode"/> exceeds the varint range.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Equivalent to <c>Multibase.EncodeBase58Btc(Multihash.Encode(hashFunctionCode, digest), includeMultibasePrefix)</c>.
+    /// Do not substitute <see cref="Multicodec.Prefix"/> for the multihash step: it omits the
+    /// digest-length varint and does not produce a multihash.
+    /// </para>
+    /// <para>
+    /// For multicodec-tagged public keys (<c>did:key</c>, <c>publicKeyMultibase</c>) use
+    /// <see cref="Multikey"/> instead — there the correct shape is a multicodec prefix plus
+    /// <c>'z'</c> multibase, not a multihash.
+    /// </para>
+    /// <para>
+    /// To decode, compose the existing primitives: <see cref="Multibase.DecodeBase58Btc(string)"/>
+    /// (bare) or <see cref="Multibase.Decode(string)"/> (multibase) followed by
+    /// <see cref="Decode"/>. No combined decoder is provided because a bare base58btc string can
+    /// itself begin with <c>'z'</c>, making a decoder that accepts either form ambiguous.
+    /// </para>
+    /// </remarks>
+    public static string EncodeBase58Btc(ulong hashFunctionCode, ReadOnlySpan<byte> digest, bool includeMultibasePrefix)
+        => Multibase.EncodeBase58Btc(Encode(hashFunctionCode, digest), includeMultibasePrefix);
 
     /// <summary>
     /// Decode a multihash byte sequence into its hash function code and raw digest.

--- a/NetCid/Multihash.cs
+++ b/NetCid/Multihash.cs
@@ -15,6 +15,9 @@ public static class Multihash
     /// varint(codec) || data with no digest-length varint and is not a multihash.
     /// For a SHA-256 digest a multihash is 34 bytes (<c>0x12 0x20 || digest</c>);
     /// the multicodec-tagged form is 33 bytes.
+    /// The digest length is encoded from the actual span, never validated against
+    /// <paramref name="hashFunctionCode"/> — supply a digest of the correct length
+    /// for the declared hash function.
     /// </remarks>
     public static byte[] Encode(ulong hashFunctionCode, ReadOnlySpan<byte> digest)
         => new MultihashDigest(hashFunctionCode, digest).ToByteArray();
@@ -24,7 +27,11 @@ public static class Multihash
     /// and render it as base58btc text in one call.
     /// </summary>
     /// <param name="hashFunctionCode">The multihash function code, e.g. <see cref="MultihashCode.Sha2_256"/>.</param>
-    /// <param name="digest">The raw digest bytes.</param>
+    /// <param name="digest">
+    /// The raw digest bytes. The length is encoded from the actual span, never validated
+    /// against <paramref name="hashFunctionCode"/> — supply a digest of the correct length
+    /// for the declared hash function.
+    /// </param>
     /// <param name="includeMultibasePrefix">
     /// <see langword="true"/> to return a self-describing multibase string with a leading <c>'z'</c>
     /// (use when the governing protocol says <c>multibase(...)</c>);

--- a/NetCid/NetCid.csproj
+++ b/NetCid/NetCid.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>NetCid</PackageId>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Authors>NetCid Contributors</Authors>
     <Description>Multiformats CID implementation for .NET.</Description>
     <PackageTags>cid;multiformats;ipfs;multibase;multicodec;multihash</PackageTags>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Unsigned varint codec (multiformats-compatible, max 9-byte encoding)
 - Multihash model + SHA-256 / SHA-512 hash helpers
 - `Multihash.Encode` / `Decode` for spec-compliant multihash wire format (`varint(code) || varint(digestLength) || digest`)
+- `Multihash.EncodeBase58Btc` — complete multihash → base58btc text in one call, with bare-vs-`z`-multibase stated explicitly at the call site (see [Multihash vs Multicodec.Prefix](#multihash-vs-multicodecprefix-and-bare-vs-multibase-base58btc))
 - Multibase support for:
   - `base58btc` (`z`)
   - `base32` lower/upper (`b` / `B`)
@@ -59,6 +60,57 @@ var entry = new System.Text.Json.Nodes.JsonObject
 };
 var jsonCid = Cid.FromCanonicalJson(entry);
 ```
+
+## Multihash vs Multicodec.Prefix, and bare vs multibase base58btc
+
+Two API pairs look interchangeable but produce different wire formats. Mixing them up
+produces values that look plausible and even round-trip against themselves, yet fail
+interoperability (this bit did:webvh SCIDs downstream in
+[net-did#95](https://github.com/moisesja/net-did/issues/95)).
+
+**Axis 1 — tagged bytes vs complete multihash.** `Multicodec.Prefix` emits
+`varint(codec) || data` with no digest-length varint; a multihash additionally encodes the
+digest length. For SHA-256:
+
+```text
+Multicodec.Prefix(0x12, digest):   0x12 || <32 bytes>          = 33 bytes (NOT a multihash)
+Multihash.Encode(0x12, digest):    0x12 || 0x20 || <32 bytes>  = 34 bytes (multihash)
+```
+
+**Axis 2 — bare base58btc vs base58btc multibase.** "base58btc" in a protocol spec does not
+automatically mean multibase: multibase adds a separate leading `z`. Beware the differing
+defaults — `Multibase.Encode(..., includePrefix: true)` vs
+`Multibase.EncodeBase58Btc(..., includePrefix: false)` — and prefer passing the argument
+explicitly.
+
+```csharp
+// Multicodec-tagged payload (for formats that require only a codec tag)
+var tagged = Multicodec.Prefix(codec, payload);
+
+// Complete multihash (algorithm code + digest length + digest)
+var multihash = Multihash.Encode(MultihashCode.Sha2_256, sha256Digest);
+
+// Bare base58btc, when the governing protocol says base58btc(...)
+var bare = Multibase.Encode(multihash, MultibaseEncoding.Base58Btc, includePrefix: false);
+
+// Multibase base58btc, when the governing protocol says multibase(...)
+var selfDescribing = Multibase.Encode(multihash, MultibaseEncoding.Base58Btc, includePrefix: true);
+
+// Recommended one-call composition for multihash → base58btc; the multibase flag is
+// required so the intent is visible at every call site.
+var scid = Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, sha256Digest, includeMultibasePrefix: false);
+```
+
+Known-answer example: SHA-256 of the UTF-8 string
+`z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK` gives digest
+`79d8444cc417275da1aa2ed425afb37ba26353270bb09fa29ef8aa4318e13f41`, multihash bytes
+`1220` + digest, bare base58btc `QmWYHJqmhJHuzQHMQ33piy86hYQwwNBKEFmCKzRMTi7UHN`
+(multibase form is the same string with a leading `z`). Bare base58btc of a SHA-256
+multihash commonly begins with `Qm`.
+
+`Multicodec.Prefix` + `z`-multibase is not wrong everywhere — it is exactly the required
+shape for multicodec-tagged public keys (`did:key`, `publicKeyMultibase`); use `Multikey`
+for those.
 
 ## Specification Notes
 

--- a/examples/multibase-interface/Program.cs
+++ b/examples/multibase-interface/Program.cs
@@ -22,6 +22,19 @@ foreach (var encoding in encodings)
     Console.WriteLine($"  {encoding,-12} (prefix '{Multibase.GetPrefix(encoding)}'): {encoded}");
 }
 
+// --- Bare base58btc vs base58btc multibase ---
+
+Console.WriteLine("\nBare base58btc vs base58btc multibase (note the differing defaults):\n");
+
+// Multibase.Encode defaults includePrefix: true; Multibase.EncodeBase58Btc defaults
+// includePrefix: false. "base58btc" in a spec does not automatically mean multibase —
+// pass the argument explicitly so the intent is visible.
+var bareB58 = Multibase.EncodeBase58Btc(content, includePrefix: false);
+var multibaseB58 = Multibase.Encode(content, MultibaseEncoding.Base58Btc, includePrefix: true);
+
+Console.WriteLine($"  EncodeBase58Btc(..., includePrefix: false): {bareB58}");
+Console.WriteLine($"  Encode(..., Base58Btc, includePrefix: true): {multibaseB58}");
+
 // --- Decode with auto-detection ---
 
 Console.WriteLine("\nAuto-detecting encoding from multibase prefix:\n");

--- a/examples/multihash-interface/Program.cs
+++ b/examples/multihash-interface/Program.cs
@@ -37,6 +37,22 @@ var incorrectPrefix = Multicodec.Prefix(MultihashCode.Sha2_256, rawDigest);
 Console.WriteLine($"\n  Multicodec.Prefix (WRONG for multihash): {incorrectPrefix.Length} bytes — missing digest length varint");
 Console.WriteLine($"  Multihash.Encode  (CORRECT):             {multihash.Length} bytes — includes digest length varint");
 
+// --- Multihash.EncodeBase58Btc (multihash → base58btc in one call) ---
+
+Console.WriteLine("\nMultihash.EncodeBase58Btc (multihash → base58btc in one call):\n");
+
+// Known-answer vector from issue #62
+var knownInput = System.Text.Encoding.UTF8.GetBytes("z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+var knownDigest = SHA256.HashData(knownInput);
+
+// The multibase flag is required: bare base58btc and 'z'-multibase are different wire formats.
+var bare = Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, knownDigest, includeMultibasePrefix: false);
+var multibase = Multihash.EncodeBase58Btc(MultihashCode.Sha2_256, knownDigest, includeMultibasePrefix: true);
+
+Console.WriteLine($"  bare base58btc (protocol says base58btc(...)):  {bare}");
+Console.WriteLine($"  multibase      (protocol says multibase(...)):  {multibase}");
+Console.WriteLine($"  Expected bare: QmWYHJqmhJHuzQHMQ33piy86hYQwwNBKEFmCKzRMTi7UHN — match: {bare == "QmWYHJqmhJHuzQHMQ33piy86hYQwwNBKEFmCKzRMTi7UHN"}");
+
 // --- Multihash.Decode round-trip ---
 
 Console.WriteLine("\nMultihash.Decode round-trip:\n");


### PR DESCRIPTION
Closes #62.

Ergonomics/documentation hardening prompted by moisesja/net-did#95 — **not** a wire-format correction; NetCid's existing primitives are unchanged and nothing is deprecated.

## What changed

- **New API — `Multihash.EncodeBase58Btc(hashFunctionCode, digest, includeMultibasePrefix)`**: encodes the complete multihash (`varint(code) ‖ varint(len) ‖ digest`) and renders it as base58btc in one call. The multibase flag is **required (no default)** per the issue's guidance, so bare-vs-`z` intent is explicit at every call site. Deliberately no decode counterpart: a bare base58btc string can itself begin with `z`, so an accept-either decoder would recreate the trap in reverse; the XML docs show the decode composition instead.
- **XML doc hardening (docs-only)**: `Multibase.Encode` vs `Multibase.EncodeBase58Btc` opposite `includePrefix` defaults called out with a recommendation to pass the argument explicitly; `DecodeBase58Btc` bare-payload semantics (leading `z` is a digit, not stripped); `Multicodec.Prefix` now states its output is multicodec-tagged data, **not** a multihash (33 vs 34 bytes for SHA-256), routing digest callers to `Multihash` and key callers to `Multikey`.
- **README**: new "Multihash vs Multicodec.Prefix, and bare vs multibase base58btc" section with the issue's side-by-side compositions, byte-count comparison, and known-answer vector.
- **Tests** (6 new, in `MultihashTests`): known-answer vector verified independently before pinning (sha256 of the issue's UTF-8 input → `1220…` multihash → `QmWYHJ…` bare / `zQmWYHJ…` multibase); structural wire-shape asserts (34 bytes, `0x12`, `0x20`, digest, no `z` when bare); manual-composition equivalence; `Multicodec.Prefix`-divergence regression guard (the exact net-did#95 misuse); oversized-code `ArgumentOutOfRangeException`.
- **Examples**: multihash example demonstrates the helper against the known vector; multibase example shows the differing defaults.
- **Version bump to 1.6.1**: `CHANGELOG.md` gains `[1.6.1]` + compare links. `PackageValidationBaselineVersion` intentionally stays `1.5.0` (last *published* version; baseline bumps only post-publish per the csproj checklist).

## Acceptance criteria mapping

- [x] Docs distinguish multicodec-tagged data vs complete multihash (README section, `Multicodec.Prefix`/`Multihash.Encode` XML docs)
- [x] Docs distinguish bare base58btc vs base58btc multibase (README, `Multibase` XML docs)
- [x] Discoverable recommended composition (`Multihash.EncodeBase58Btc`, unambiguous required flag)
- [x] Known-answer example/test asserts `code ‖ length ‖ digest` wire shape
- [x] Existing valid uses of `Multicodec.Prefix` / prefix-bearing multibase unchanged (additive-only; package validation green)
- [x] Documented as ergonomics/hardening, not a wire-format correction (CHANGELOG wording)

## Verification

- `dotnet restore --locked-mode` / `build -c Release`: clean, 0 warnings
- `dotnet test` unit: 322 passed / integration: 6 passed
- `dotnet pack` (package validation vs 1.5.0 baseline): green — additive API only
- Both examples run; printed vector matches `QmWYHJqmhJHuzQHMQ33piy86hYQwwNBKEFmCKzRMTi7UHN` / `z`-prefixed form
- Known-answer vector independently reproduced (python3 sha256+base58) before being pinned into tests

Adversarial review runs in parallel with CI; findings land as follow-up commits on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)